### PR TITLE
[WIP] Bot factory

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,14 +1,3 @@
 use Mix.Config
 
-config :exvcr,
-  vcr_cassette_library_dir: "test/fixtures/vcr_cassettes",
-  custom_cassette_library_dir: "test/fixtures/custom_cassettes",
-  filter_sensitive_data: [
-    [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"],
-    [pattern: "token=([^&#]*)", placeholder: "token=***"]
-  ],
-  filter_request_headers: [
-    "X-Slack-Req-Id",
-    "X-Via",
-    "X-Amz-Cf-Id"
-  ]
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,14 @@
+use Mix.Config
+
+config :exvcr,
+  vcr_cassette_library_dir: "test/fixtures/vcr_cassettes",
+  custom_cassette_library_dir: "test/fixtures/custom_cassettes",
+  filter_sensitive_data: [
+    [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"],
+    [pattern: "token=([^&#]*)", placeholder: "token=***"]
+  ],
+  filter_request_headers: [
+    "X-Slack-Req-Id",
+    "X-Via",
+    "X-Amz-Cf-Id"
+  ]

--- a/lib/juvet.ex
+++ b/lib/juvet.ex
@@ -1,0 +1,12 @@
+defmodule Juvet do
+  use Application
+
+  def start(_types, _args) do
+    children = [
+      Supervisor.Spec.supervisor(PubSub, []),
+      Supervisor.Spec.supervisor(Juvet.BotFactorySupervisor, [])
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_all)
+  end
+end

--- a/lib/juvet/bot.ex
+++ b/lib/juvet/bot.ex
@@ -26,7 +26,7 @@ defmodule Juvet.Bot do
     {:reply, state, state}
   end
 
-  def handle_info(message, state) do
+  def handle_info([:incoming_slack_message, message], state) do
     IO.puts("BOT RECEIVED INFO " <> inspect(message))
     {:noreply, state}
   end

--- a/lib/juvet/bot.ex
+++ b/lib/juvet/bot.ex
@@ -1,20 +1,33 @@
 defmodule Juvet.Bot do
   use GenServer
 
-  def start_link(options \\ %{}) do
-    GenServer.start_link(__MODULE__, options)
+  def start_link(%{team: %{domain: domain}} = initial_message) do
+    GenServer.start_link(
+      __MODULE__,
+      initial_message,
+      name: String.to_atom(domain)
+    )
   end
 
-  # Server
-  def init(args) do
+  def get_state(pid) do
+    GenServer.call(pid, :get_state)
+  end
+
+  # Callbacks
+  def init(initial_message) do
     ## Subscribe to messages
+
     PubSub.subscribe(self(), :incoming_slack_message)
 
-    {:ok, args}
+    {:ok, initial_message}
+  end
+
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
   end
 
   def handle_info(message, state) do
-    IO.puts("RECEIVED INFO " <> inspect(message))
+    IO.puts("BOT RECEIVED INFO " <> inspect(message))
     {:noreply, state}
   end
 end

--- a/lib/juvet/bot.ex
+++ b/lib/juvet/bot.ex
@@ -1,6 +1,24 @@
 defmodule Juvet.Bot do
   use GenServer
 
+  @moduledoc """
+  A behavior module for implementing a bot.
+
+  A bot can be targeted for one or many platforms. The main function
+  to implement is the `handle_message` function which will fire for
+  any incoming message to the bot. The `send` function will send any
+  message back to the server.
+  """
+
+  @doc ~S"""
+  Starts a new bot process for Slack.
+
+  Returns `{:ok, pid}` where `pid` is the process id of this bot.
+
+  ## Example
+
+  {:ok, pid} = Juvet.Bot.start_link(initial_message)
+  """
   def start_link(%{team: %{domain: domain}} = initial_message) do
     GenServer.start_link(
       __MODULE__,
@@ -9,23 +27,34 @@ defmodule Juvet.Bot do
     )
   end
 
+  @doc ~S"""
+  Returns the current state of the Slack process.
+
+  ## Example
+
+  {:ok, pid} = Juvet.Bot.start_link(initial_message)
+  message = Juvet.Bot.get_state(pid)
+  """
   def get_state(pid) do
     GenServer.call(pid, :get_state)
   end
 
-  # Callbacks
+  ## Callbacks
+
+  @doc false
   def init(initial_message) do
     ## Subscribe to messages
-
     PubSub.subscribe(self(), :incoming_slack_message)
 
     {:ok, initial_message}
   end
 
+  @doc false
   def handle_call(:get_state, _from, state) do
     {:reply, state, state}
   end
 
+  @doc false
   def handle_info([:incoming_slack_message, message], state) do
     IO.puts("BOT RECEIVED INFO " <> inspect(message))
     {:noreply, state}

--- a/lib/juvet/bot_factory.ex
+++ b/lib/juvet/bot_factory.ex
@@ -1,0 +1,48 @@
+defmodule Juvet.BotFactory do
+  use GenServer
+
+  def start_link(supervisor, config) do
+    GenServer.start_link(__MODULE__, [supervisor, config], name: __MODULE__)
+  end
+
+  # Callbacks
+  def init([supervisor, config]) when is_pid(supervisor) do
+    init(config, %{supervisor: supervisor})
+  end
+
+  def init(_config, state) do
+    PubSub.subscribe(self(), :new_slack_connection)
+
+    send(self(), :start_bot_supervisor)
+
+    {:ok, state}
+  end
+
+  def handle_info(:start_bot_supervisor, %{supervisor: supervisor} = state) do
+    {:ok, bot_supervisor} =
+      Supervisor.start_child(supervisor, bot_supervisor_spec())
+
+    {:noreply, Map.merge(state, %{bot_supervisor: bot_supervisor})}
+  end
+
+  # Handle when a new bot is created...
+  def handle_info(
+        %{ok: true} = message,
+        %{bot_supervisor: bot_supervisor} = state
+      ) do
+    Supervisor.start_child(
+      bot_supervisor,
+      Supervisor.Spec.worker(Juvet.Bot, [message])
+    )
+
+    {:noreply, state}
+  end
+
+  defp bot_supervisor_spec() do
+    Supervisor.Spec.supervisor(
+      Juvet.BotSupervisor,
+      [],
+      restart: :permanent
+    )
+  end
+end

--- a/lib/juvet/bot_factory.ex
+++ b/lib/juvet/bot_factory.ex
@@ -43,8 +43,7 @@ defmodule Juvet.BotFactory do
     {:noreply, Map.merge(state, %{bot_supervisor: bot_supervisor})}
   end
 
-  # Handle when a new bot is created...
-  def handle_info(%{ok: true} = message, state) do
+  def handle_info([:new_slack_connection, %{ok: true} = message], state) do
     BotFactory.add_bot(message)
 
     {:noreply, state}

--- a/lib/juvet/bot_factory.ex
+++ b/lib/juvet/bot_factory.ex
@@ -1,21 +1,53 @@
 defmodule Juvet.BotFactory do
   use GenServer
 
+  @moduledoc """
+  A Module for instructing a supervisor on adding and removing bot
+  processes.
+  """
+
   alias Juvet.BotFactory
 
+  @doc ~S"""
+  Starts a new process for managing bots in an application.
+
+  Upon initialization, this adds this bot factory as a child process to
+  a bot supervisor. In addition, another supervisor is created as a
+  sibling to this bot factory work process which supervises all of the
+  bots that are added through this factory.
+
+  Returns `{:ok, pid}` where `pid` is the process id of this factory.
+
+  ## Example
+
+  {:ok, pid} = Juvet.BotFactory.start_link(supervisor_pid, %{})
+  """
   def start_link(supervisor, config) do
     GenServer.start_link(__MODULE__, [supervisor, config], name: __MODULE__)
   end
 
+  @doc ~S"""
+  Adds a new bot process to the bot supervisor with the `message` as an
+  argument.
+
+  Returns `:ok`.
+
+  ## Example
+
+  :ok = Juvet.BotFactory.add_bot(%{team: %{domain: "Led Zeppelin"}})
+  """
   def add_bot(message) do
     GenServer.cast(BotFactory, {:add_bot, message})
   end
 
-  # Callbacks
+  ## Callbacks
+
+  @doc false
   def init([supervisor, config]) when is_pid(supervisor) do
     init(config, %{supervisor: supervisor})
   end
 
+  @doc false
   def init(_config, state) do
     PubSub.subscribe(self(), :new_slack_connection)
 
@@ -24,6 +56,7 @@ defmodule Juvet.BotFactory do
     {:ok, state}
   end
 
+  @doc false
   def handle_cast(
         {:add_bot, message},
         %{bot_supervisor: bot_supervisor} = state
@@ -36,6 +69,7 @@ defmodule Juvet.BotFactory do
     {:noreply, state}
   end
 
+  @doc false
   def handle_info(:start_bot_supervisor, %{supervisor: supervisor} = state) do
     {:ok, bot_supervisor} =
       Supervisor.start_child(supervisor, bot_supervisor_spec())
@@ -43,12 +77,14 @@ defmodule Juvet.BotFactory do
     {:noreply, Map.merge(state, %{bot_supervisor: bot_supervisor})}
   end
 
+  @doc false
   def handle_info([:new_slack_connection, %{ok: true} = message], state) do
     BotFactory.add_bot(message)
 
     {:noreply, state}
   end
 
+  @doc false
   defp bot_supervisor_spec() do
     Supervisor.Spec.supervisor(
       Juvet.BotSupervisor,

--- a/lib/juvet/bot_factory_supervisor.ex
+++ b/lib/juvet/bot_factory_supervisor.ex
@@ -1,11 +1,28 @@
 defmodule Juvet.BotFactorySupervisor do
   use Supervisor
 
+  @moduledoc """
+  A supervisor that supervises a worker `BotFactory` process and
+  another supervisor `BotSupervisor` which in turn, supervises all
+  of the bot processes.
+  """
+
+  @doc ~S"""
+  Starts a new bot factory supervisor
+
+  Returns `{:ok, pid}` where `pid` is the process id of this supervisor.
+
+  ## Example
+
+  {:ok, pid} = Juvet.BotFactorySupervisor.start_link()
+  """
   def start_link() do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  # Callbacks
+  ## Callbacks
+
+  @doc false
   def init(_args) do
     children = [
       worker(Juvet.BotFactory, [self(), []])

--- a/lib/juvet/bot_factory_supervisor.ex
+++ b/lib/juvet/bot_factory_supervisor.ex
@@ -1,0 +1,16 @@
+defmodule Juvet.BotFactorySupervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  # Callbacks
+  def init(_args) do
+    children = [
+      worker(Juvet.BotFactory, [self(), []])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/juvet/bot_supervisor.ex
+++ b/lib/juvet/bot_supervisor.ex
@@ -1,0 +1,13 @@
+defmodule Juvet.BotSupervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  # Callbacks
+
+  def init(_args) do
+    supervise([], strategy: :one_for_one)
+  end
+end

--- a/lib/juvet/connection/slack_rtm.ex
+++ b/lib/juvet/connection/slack_rtm.ex
@@ -1,13 +1,32 @@
 defmodule Juvet.Connection.SlackRTM do
   use WebSockex
 
+  @moduledoc """
+  A process to start a websocket connection to the Slack RTM api.
+  """
+
   alias Juvet.{SlackAPI}
 
+  @doc ~S"""
+  Makes a call to the Slack API RTM.connect endpoint with the specified
+  `token` and uses that url to connect to the websocket server on Slack.
+
+  ## Example
+
+  {:ok, pid} = Juvet.Connection.SlackRTM.connect(%{token: token})
+  """
   def connect(%{token: _token} = parameters) do
     SlackAPI.RTM.connect(parameters)
     |> start_link
   end
 
+  @doc ~S"""
+    Returns the current state of the Slack process.
+
+    ## Example
+
+    {:ok, pid} = Juvet.Connection.SlackRTM.get_state(pid)
+  """
   def get_state(pid) do
     {:ok, :sys.get_state(pid)}
   end
@@ -18,21 +37,29 @@ defmodule Juvet.Connection.SlackRTM do
     {:ok, state}
   end
 
+  @doc ~S"""
+  Handles when the SlackRTM receives a disconnected message from PubSub.
+  """
   def handle_disconnect(_, state) do
     PubSub.publish(:slack_disconnected, [:slack_disconnected, state])
 
     {:ok, state}
   end
 
+  @doc ~S"""
+  Handles when the SlackRTM receives a incoming message from PubSub.
+  """
   def handle_frame({_type, message}, state) do
     PubSub.publish(:incoming_slack_message, [:incoming_slack_message, message])
 
     {:ok, state}
   end
 
+  @doc false
   defp start_link({:ok, %{url: url} = response}) do
     WebSockex.start_link(url, __MODULE__, response)
   end
 
+  @doc false
   defp start_link({:error, _} = response), do: response
 end

--- a/lib/juvet/connection/slack_rtm.ex
+++ b/lib/juvet/connection/slack_rtm.ex
@@ -13,19 +13,19 @@ defmodule Juvet.Connection.SlackRTM do
   end
 
   def handle_connect(_conn, %{ok: true} = state) do
-    PubSub.publish(:new_slack_connection, state)
+    PubSub.publish(:new_slack_connection, [:new_slack_connection, state])
 
     {:ok, state}
   end
 
   def handle_disconnect(_, state) do
-    PubSub.publish(:slack_disconnected, state)
+    PubSub.publish(:slack_disconnected, [:slack_disconnected, state])
 
     {:ok, state}
   end
 
   def handle_frame({_type, message}, state) do
-    PubSub.publish(:incoming_slack_message, message)
+    PubSub.publish(:incoming_slack_message, [:incoming_slack_message, message])
 
     {:ok, state}
   end

--- a/lib/juvet/slack_api.ex
+++ b/lib/juvet/slack_api.ex
@@ -3,26 +3,49 @@ defmodule Juvet.SlackAPI do
 
   alias Juvet.SlackAPI
 
+  @moduledoc """
+  Helper methods to help process the response from Slack.
+  """
+
+  @doc ~S"""
+  Returns an error tuple if the body contains an `ok: false` node.
+  """
   def handle_response({:ok, %{ok: false} = body}) do
     {:error, body}
   end
 
+  @doc ~S"""
+  Returns an ok tuple if the body contains an `ok: true` node.
+  """
   def handle_response({:ok, %{ok: true} = body}) do
     {:ok, body}
   end
 
+  @doc ~S"""
+  Decodes a JSON response and converts it into a Map.
+  """
   def parse_response({:ok, %HTTPoison.Response{body: body}}) do
     response = body |> Poison.decode!(keys: :atoms)
     {:ok, response}
   end
 
+  @doc """
+  Parses and handles the response from the Slack API.
+  """
   def render_response(tuple), do: parse_response(tuple) |> handle_response
 
+  @doc ~S"""
+  Returns the url for what url the API should use a the base url along
+  with the current endpoint.
+  """
   def process_url(endpoint) do
     url = Application.get_env(:slack, :url, "https://slack.com")
     "#{url}/api/#{endpoint}"
   end
 
+  @doc ~S"""
+  Make the request to the endpoint and returns that response.
+  """
   def request(endpoint, body) do
     SlackAPI.get(
       endpoint,
@@ -31,6 +54,7 @@ defmodule Juvet.SlackAPI do
     )
   end
 
+  @doc false
   defp headers do
     %{
       "Content-Type" => "application/json",

--- a/lib/juvet/slack_api/rtm.ex
+++ b/lib/juvet/slack_api/rtm.ex
@@ -1,6 +1,33 @@
 defmodule Juvet.SlackAPI.RTM do
   alias Juvet.SlackAPI
 
+  @moduledoc """
+  A wrapper around the rtm methods on the Slack API.
+  """
+
+  @doc ~S"""
+  Requests a new connection via websockets for the Slack API
+  and retrieves a websocket address as well as some information
+  about the team and the user that requested the connection.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    url: "ws://...",
+    self: %{
+      id: "U01234",
+      name: "Jimmy Page"
+    },
+    team: %{
+      domain: "Led Zeppelin",
+      id: "T67328"
+    }
+  } = Juvet.Connection.SlackRTM.connect(%{token: token})
+  """
+
   def connect(options \\ %{}) do
     SlackAPI.request("rtm.connect", options)
     |> SlackAPI.render_response()

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,13 @@ defmodule Juvet.Mixfile do
     ]
   end
 
+  def application do
+    [
+      mod: {Juvet, []},
+      extra_applications: [:logger, :httpoison, :websockex]
+    ]
+  end
+
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 

--- a/test/juvet/bot_factory_supervisor_test.exs
+++ b/test/juvet/bot_factory_supervisor_test.exs
@@ -1,0 +1,13 @@
+defmodule Juvet.BotFactorySupervisor.BotFactorySupervisorTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.{BotFactorySupervisor, BotFactory}
+
+  describe "BotFactorySupervisor.start_link\0" do
+    test "starts the bot factory" do
+      BotFactorySupervisor.start_link()
+
+      assert Process.whereis(BotFactory) |> Process.alive?()
+    end
+  end
+end

--- a/test/juvet/bot_factory_test.exs
+++ b/test/juvet/bot_factory_test.exs
@@ -22,7 +22,7 @@ defmodule Juvet.BotFactory.BotFactoryTest do
       :ok = BotFactory.add_bot(%{ok: true, team: %{domain: "Led Zeppelin"}})
 
       # Hack to ensure the child is mounted
-      :timer.sleep(100)
+      :timer.sleep(800)
       children = Supervisor.which_children(BotSupervisor)
 
       assert [{Juvet.Bot, _pid, :worker, [Juvet.Bot]}] = children

--- a/test/juvet/bot_factory_test.exs
+++ b/test/juvet/bot_factory_test.exs
@@ -1,0 +1,19 @@
+defmodule Juvet.BotFactory.BotFactoryTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.{BotFactory, BotFactorySupervisor}
+
+  describe "BotFactory.start_link\2" do
+    test "adds itself as a child to a supervisor" do
+      [_ | t] = Supervisor.which_children(BotFactorySupervisor)
+
+      assert [{Juvet.BotFactory, _pid, :worker, [Juvet.BotFactory]}] = t
+    end
+
+    test "listens for new slack connections and adds a bot" do
+      subscribers = PubSub.subscribers(:new_slack_connection)
+
+      assert subscribers == [Process.whereis(BotFactory)]
+    end
+  end
+end

--- a/test/juvet/bot_factory_test.exs
+++ b/test/juvet/bot_factory_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.BotFactory.BotFactoryTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.{BotFactory, BotFactorySupervisor}
+  alias Juvet.{BotFactory, BotFactorySupervisor, BotSupervisor}
 
   describe "BotFactory.start_link\2" do
     test "adds itself as a child to a supervisor" do
@@ -14,6 +14,18 @@ defmodule Juvet.BotFactory.BotFactoryTest do
       subscribers = PubSub.subscribers(:new_slack_connection)
 
       assert subscribers == [Process.whereis(BotFactory)]
+    end
+  end
+
+  describe "BotFactory.add_bot\2" do
+    test "adds a bot process to the bot supervisor" do
+      :ok = BotFactory.add_bot(%{ok: true, team: %{domain: "Led Zeppelin"}})
+
+      # Hack to ensure the child is mounted
+      :timer.sleep(100)
+      children = Supervisor.which_children(BotSupervisor)
+
+      assert [{Juvet.Bot, _pid, :worker, [Juvet.Bot]}] = children
     end
   end
 end

--- a/test/juvet/bot_test.exs
+++ b/test/juvet/bot_test.exs
@@ -1,0 +1,36 @@
+defmodule Juvet.Bot.BotTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.Bot
+
+  describe "Bot.start_link\1" do
+    setup do
+      message = %{
+        ok: true,
+        team: %{
+          domain: "Led Zeppelin"
+        }
+      }
+
+      {:ok, message: message}
+    end
+
+    test "returns a pid", %{message: message} do
+      assert {:ok, _pid} = Bot.start_link(message)
+    end
+
+    test "sets the state to the initial message", %{message: message} do
+      {:ok, pid} = Bot.start_link(message)
+
+      assert Bot.get_state(pid) == message
+    end
+
+    test "names the process with the Slack domain", %{
+      message: %{team: %{domain: domain}} = message
+    } do
+      Bot.start_link(message)
+
+      assert Process.whereis(String.to_atom(domain)) |> Process.alive?()
+    end
+  end
+end

--- a/test/juvet/connection/slack_rtm_test.exs
+++ b/test/juvet/connection/slack_rtm_test.exs
@@ -77,7 +77,7 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
 
       SlackRTM.handle_frame({:text, message}, %{})
 
-      assert_receive message
+      assert_receive ^message
     end
   end
 end

--- a/test/juvet/connection/slack_rtm_test.exs
+++ b/test/juvet/connection/slack_rtm_test.exs
@@ -56,7 +56,10 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
         SlackRTM.connect(%{token: token})
       end
 
-      assert_receive %{ok: true, team: %{name: "Brilliant Fantastic"}}
+      assert_receive [
+        :new_slack_connection,
+        %{ok: true, team: %{name: "Brilliant Fantastic"}}
+      ]
     end
 
     test "publishes a disconnection message when disconnected", %{token: token} do
@@ -68,7 +71,10 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
         SlackRTM.handle_disconnect(nil, state)
       end
 
-      assert_receive %{ok: true, team: %{name: "Brilliant Fantastic"}}
+      assert_receive [
+        :slack_disconnected,
+        %{ok: true, team: %{name: "Brilliant Fantastic"}}
+      ]
     end
 
     test "publishes the message to incoming slack message subscribers" do
@@ -77,7 +83,7 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
 
       SlackRTM.handle_frame({:text, message}, %{})
 
-      assert_receive ^message
+      assert_receive [:incoming_slack_message, ^message]
     end
   end
 end

--- a/test/juvet/connection/slack_rtm_test.exs
+++ b/test/juvet/connection/slack_rtm_test.exs
@@ -49,14 +49,6 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
   end
 
   describe "receiving incoming Slack messages" do
-    setup do
-      {:ok, pub_sub} = PubSub.start_link()
-
-      on_exit(fn ->
-        PubSub.terminate(pub_sub, :shutdown)
-      end)
-    end
-
     test "publishes a connection message when connected", %{token: token} do
       PubSub.subscribe(self(), :new_slack_connection)
 

--- a/test/juvet_test.exs
+++ b/test/juvet_test.exs
@@ -1,0 +1,13 @@
+defmodule Juvet.JuvetTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.start/2" do
+    test "starts the pub sub process" do
+      assert Process.whereis(PubSub) |> Process.alive?()
+    end
+
+    test "starts the bot factory supervisor" do
+      assert Process.whereis(Juvet.BotFactorySupervisor) |> Process.alive?()
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `BotFactory` that is in charge of assigning new bots to a supervisor.

`JuvetBotFactorySupervisor` -> Supervisor that supervises a bot factory and a bot worker supervisor
`Juvet.BotFactory` -> is a worker under `Juvet.BotFactorySupervisor` and is in charge of adding and removing bot workers
`JuvetBotSupervisor` -> is a supervisor that supervises `Juvet.Bot` workers

## TODO:
- [x] Extract the adding of a bot to a function (`add_bot`) on `BotFactory`
- [x] Add documentation to the supervisor trees
- [x] Look into seeing if a `DynamicSupervisor` should be used on `BotSupervisor`
- [x] Update PubSub so the message name is part of the message so it can be pattern matched easily
  ```
  PubSub.publish(:new_slack_message, [:new_slack_message, message])
  ```

**NOT READY FOR MERGING**

Closes #7 