### PR TITLE
Connection supervisor tree

### DIFF
--- a/lib/juvet.ex
+++ b/lib/juvet.ex
@@ -4,7 +4,8 @@ defmodule Juvet do
   def start(_types, _args) do
     children = [
       Supervisor.Spec.supervisor(PubSub, []),
-      Supervisor.Spec.supervisor(Juvet.BotFactorySupervisor, [])
+      Supervisor.Spec.supervisor(Juvet.BotFactorySupervisor, []),
+      Supervisor.Spec.supervisor(Juvet.ConnectionFactorySupervisor, [])
     ]
 
     Supervisor.start_link(children, strategy: :one_for_all)

--- a/lib/juvet/bot_factory.ex
+++ b/lib/juvet/bot_factory.ex
@@ -61,9 +61,9 @@ defmodule Juvet.BotFactory do
         {:add_bot, message},
         %{bot_supervisor: bot_supervisor} = state
       ) do
-    Supervisor.start_child(
+    DynamicSupervisor.start_child(
       bot_supervisor,
-      Supervisor.Spec.worker(Juvet.Bot, [message])
+      {Juvet.Bot, message}
     )
 
     {:noreply, state}

--- a/lib/juvet/bot_supervisor.ex
+++ b/lib/juvet/bot_supervisor.ex
@@ -1,13 +1,13 @@
 defmodule Juvet.BotSupervisor do
-  use Supervisor
+  use DynamicSupervisor
 
   def start_link() do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   # Callbacks
 
-  def init(_args) do
-    supervise([], strategy: :one_for_one)
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/lib/juvet/connection_factory.ex
+++ b/lib/juvet/connection_factory.ex
@@ -29,7 +29,7 @@ defmodule Juvet.ConnectionFactory do
         %{connection_supervisor: connection_supervisor} = state
       ) do
     {:ok, pid} =
-      Supervisor.start_child(
+      DynamicSupervisor.start_child(
         connection_supervisor,
         Supervisor.Spec.worker(
           Juvet.Connection.SlackRTM,

--- a/lib/juvet/connection_factory.ex
+++ b/lib/juvet/connection_factory.ex
@@ -1,28 +1,60 @@
 defmodule Juvet.ConnectionFactory do
   use GenServer
 
+  @moduledoc """
+  A Module for instructing a supervisor on adding and removing
+  connections to third party bot services.
+  """
+
   alias Juvet.ConnectionFactory
 
+  @doc ~S"""
+  Starts a new process for connecting bots in an application.
+
+  Upon initialization, this adds this connection factory as a child
+  process to a connection supervisor. In addition, another supervisor
+  is created as a sibling to this connection factory work process which
+  supervises all of the connections that are added through this factory.
+
+  Returns `{:ok, pid}` where `pid` is the process id of this factory.
+
+  ## Example
+
+  {:ok, pid} = Juvet.ConnectionFactory.start_link(supervisor_pid)
+  """
   def start_link(supervisor) do
     GenServer.start_link(__MODULE__, [supervisor], name: __MODULE__)
   end
 
+  @doc ~S"""
+  Adds a new connection process to the connection supervisor with the
+  `arguments` needed to connect to that `platform`.
+
+  Returns `pid` which is the process id of the connection.
+
+  ## Example
+
+  :ok = Juvet.ConnectionFactory.connect(:slack, %{token: token})
+  """
   def connect(platform, arguments) do
     GenServer.call(ConnectionFactory, {:connect, platform, arguments})
   end
 
   ## Callbacks
 
+  @doc false
   def init([supervisor]) when is_pid(supervisor) do
     init(%{supervisor: supervisor})
   end
 
+  @doc false
   def init(state) do
     send(self(), :start_connection_supervisor)
 
     {:ok, state}
   end
 
+  @doc false
   def handle_call(
         {:connect, _platform, arguments},
         _from,
@@ -41,6 +73,7 @@ defmodule Juvet.ConnectionFactory do
     {:reply, pid, state}
   end
 
+  @doc false
   def handle_info(
         :start_connection_supervisor,
         %{supervisor: supervisor} = state
@@ -52,6 +85,7 @@ defmodule Juvet.ConnectionFactory do
      Map.merge(state, %{connection_supervisor: connection_supervisor})}
   end
 
+  @doc false
   defp connection_supervisor_spec() do
     Supervisor.Spec.supervisor(
       Juvet.ConnectionSupervisor,

--- a/lib/juvet/connection_factory.ex
+++ b/lib/juvet/connection_factory.ex
@@ -1,0 +1,36 @@
+defmodule Juvet.ConnectionFactory do
+  use GenServer
+
+  def start_link(supervisor) do
+    GenServer.start_link(__MODULE__, [supervisor], name: __MODULE__)
+  end
+
+  def init([supervisor]) when is_pid(supervisor) do
+    init(%{supervisor: supervisor})
+  end
+
+  def init(state) do
+    send(self(), :start_connection_supervisor)
+
+    {:ok, state}
+  end
+
+  def handle_info(
+        :start_connection_supervisor,
+        %{supervisor: supervisor} = state
+      ) do
+    {:ok, connection_supervisor} =
+      Supervisor.start_child(supervisor, connection_supervisor_spec())
+
+    {:noreply,
+     Map.merge(state, %{connection_supervisor: connection_supervisor})}
+  end
+
+  defp connection_supervisor_spec() do
+    Supervisor.Spec.supervisor(
+      Juvet.ConnectionSupervisor,
+      [],
+      restart: :permanent
+    )
+  end
+end

--- a/lib/juvet/connection_factory_supervisor.ex
+++ b/lib/juvet/connection_factory_supervisor.ex
@@ -1,10 +1,28 @@
 defmodule Juvet.ConnectionFactorySupervisor do
   use Supervisor
 
+  @moduledoc """
+  A supervisor that supervises a worker `ConnectionFactory` process and
+  another supervisor `ConnectionSupervisor` which in turn, supervises all
+  of the connection processes.
+  """
+
+  @doc ~S"""
+  Starts a new connection factory supervisor
+
+  Returns `{:ok, pid}` where `pid` is the process id of this supervisor.
+
+  ## Example
+
+  {:ok, pid} = Juvet.ConnectionFactorySupervisor.start_link()
+  """
   def start_link() do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  ## Callbacks
+
+  @doc false
   def init(_args) do
     children = [
       worker(Juvet.ConnectionFactory, [self()])

--- a/lib/juvet/connection_factory_supervisor.ex
+++ b/lib/juvet/connection_factory_supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Juvet.ConnectionFactorySupervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_args) do
+    children = [
+      worker(Juvet.ConnectionFactory, [self()])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/juvet/connection_supervisor.ex
+++ b/lib/juvet/connection_supervisor.ex
@@ -1,0 +1,13 @@
+defmodule Juvet.ConnectionSupervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  # Callbacks
+
+  def init(_args) do
+    supervise([], strategy: :one_for_one)
+  end
+end

--- a/lib/juvet/connection_supervisor.ex
+++ b/lib/juvet/connection_supervisor.ex
@@ -1,13 +1,13 @@
 defmodule Juvet.ConnectionSupervisor do
-  use Supervisor
+  use DynamicSupervisor
 
   def start_link() do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   # Callbacks
 
-  def init(_args) do
-    supervise([], strategy: :one_for_one)
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/test/juvet/bot_factory_test.exs
+++ b/test/juvet/bot_factory_test.exs
@@ -25,7 +25,7 @@ defmodule Juvet.BotFactory.BotFactoryTest do
       :timer.sleep(800)
       children = Supervisor.which_children(BotSupervisor)
 
-      assert [{Juvet.Bot, _pid, :worker, [Juvet.Bot]}] = children
+      assert [{:undefined, _pid, :worker, [Juvet.Bot]}] = children
     end
   end
 end

--- a/test/juvet/connection_factory_supervisor_test.exs
+++ b/test/juvet/connection_factory_supervisor_test.exs
@@ -1,0 +1,13 @@
+defmodule Juvet.ConnectionFactorySupervisor.ConnectionFactorySupervisorTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.{ConnectionFactorySupervisor, ConnectionFactory}
+
+  describe "ConnectionFactorySupervisor.start_link\0" do
+    test "starts the connection factory" do
+      ConnectionFactorySupervisor.start_link()
+
+      assert Process.whereis(ConnectionFactory) |> Process.alive?()
+    end
+  end
+end

--- a/test/juvet/connection_factory_test.exs
+++ b/test/juvet/connection_factory_test.exs
@@ -1,0 +1,49 @@
+defmodule Juvet.ConnectionFactory.ConnectionFactoryTest do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  alias Juvet.{
+    ConnectionFactory,
+    ConnectionFactorySupervisor,
+    ConnectionSupervisor
+  }
+
+  setup_all do
+    Juvet.FakeSlack.start_link()
+
+    on_exit(fn ->
+      Juvet.FakeSlack.stop()
+    end)
+
+    {:ok, token: "SLACK_BOT_TOKEN"}
+  end
+
+  describe "ConnectionFactory.start_link\1" do
+    test "adds itself as a child to a supervisor" do
+      [_ | t] = Supervisor.which_children(ConnectionFactorySupervisor)
+
+      assert [
+               {Juvet.ConnectionFactory, _pid, :worker,
+                [Juvet.ConnectionFactory]}
+             ] = t
+    end
+  end
+
+  describe "ConnectionFactory.connect\2" do
+    test "adds a connection process to the connection supervisor", %{
+      token: token
+    } do
+      use_cassette "rtm/connect/successful" do
+        pid = ConnectionFactory.connect(:slack, %{token: token})
+
+        # Hack to ensure the child is mounted
+        :timer.sleep(800)
+        children = Supervisor.which_children(ConnectionSupervisor)
+
+        assert [
+                 {:undefined, ^pid, :worker, [Juvet.Connection.SlackRTM]}
+               ] = children
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a supervisor tree that mimics the one created for the bot processes. This can be improved by attaching the connection processes to the bot, I believe but this is a good starting point.

A `ConnectionFactory` will connect to the correct platform with the correct arguments. It also starts up a parent (`ConnectionFactorySupervisor`) that watches the processes for the factory and a dynamic supervisor (`ConnectionSupervisor`) for all new connections.

Closes #8 