### PR TITLE
Send message

### DIFF
--- a/lib/juvet/bot.ex
+++ b/lib/juvet/bot.ex
@@ -47,6 +47,18 @@ defmodule Juvet.Bot do
       """
       def handle_event(_platform, _message, state), do: {:ok, state}
 
+      @doc ~S"""
+      Sends a message via PubSub to the `platform` specified with the workspace `id`.
+      """
+      def send_message(platform, %{id: id} = state, message) do
+        PubSub.publish(:"outgoing_#{platform}_message_#{id}", [
+          :"outgoing_#{platform}_message",
+          message
+        ])
+
+        :ok
+      end
+
       defoverridable handle_connect: 2, handle_disconnect: 2, handle_event: 3
     end
   end

--- a/test/juvet/bot_test.exs
+++ b/test/juvet/bot_test.exs
@@ -1,0 +1,24 @@
+defmodule Juvet.Bot.BotTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestBot do
+    use Juvet.Bot
+  end
+
+  describe "Bot.send_message\1" do
+    test "publishes a message to an outgoing platform" do
+      id = "T1234"
+      PubSub.subscribe(self(), :"outgoing_slack_message_#{id}")
+
+      TestBot.send_message(:slack, %{id: id}, %{
+        type: :message,
+        text: "Hello world"
+      })
+
+      assert_receive [
+        :outgoing_slack_message,
+        %{type: :message, text: "Hello world"}
+      ]
+    end
+  end
+end

--- a/test/juvet/connection/slack_rtm_test.exs
+++ b/test/juvet/connection/slack_rtm_test.exs
@@ -87,4 +87,19 @@ defmodule Juvet.Connection.SlackRTM.SlackRTMTest do
       assert_receive [:incoming_slack_message, ^message]
     end
   end
+
+  describe "sending outgoing Slack messages" do
+    test "subscribes to outgoing slack messages", %{token: token} do
+      use_cassette "rtm/connect/successful" do
+        {:ok, _pid} = SlackRTM.connect(%{token: token})
+        id = "T1234"
+
+        SlackRTM.handle_connect(nil, %{ok: true, team: %{id: id}})
+
+        subscribers = PubSub.subscribers(:"outgoing_slack_message_#{id}")
+
+        assert length(subscribers) == 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Bot's can now send messages via Slack RTM!

The connection subscribes to a topic `:outgoing_slack_message_<id>` and a new method on the `Juvet.Bot` macro allows a message to be sent via `send_message/3`.

Closes #12