### PR TITLE
Wrap conversations.open api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ mix test
 You can re-record the responses from Slack with the following mix command:
 
 ```
-MIX_ENV=test mix record token: <slack token here> user: <slack user id here>
+MIX_ENV=test mix record token:<slack token here> user:<slack user id here> users:<slack user id here>,<another slack user id here>
 ```
 
 You can create a Slack token for any of your teams [here](https://api.slack.com/custom-integrations/legacy-tokens)/.

--- a/lib/juvet/slack_api.ex
+++ b/lib/juvet/slack_api.ex
@@ -50,8 +50,22 @@ defmodule Juvet.SlackAPI do
     SlackAPI.get(
       endpoint,
       headers(access_token),
-      params: params
+      params: request_params(params)
     )
+  end
+
+  @doc false
+  defp request_param({key, value}) when is_list(value),
+    do: {key, Enum.join(value, ",")}
+
+  @doc false
+  defp request_param(param), do: param
+
+  @doc false
+  defp request_params(params) do
+    params
+    |> Enum.map(&request_param/1)
+    |> Enum.into(%{})
   end
 
   @doc false

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -1,0 +1,27 @@
+defmodule Juvet.SlackAPI.Conversations do
+  @moduledoc """
+  A wrapper around the conversations methods on the Slack API.
+  """
+
+  alias Juvet.SlackAPI
+
+  @doc """
+  Requests a new Conversation between the requestor and the users or channel specified.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: {
+      id: "D123456"
+    }
+  } = Juvet.SlackAPI.Conversations.open(%{token: token, users: [user]})
+  """
+
+  def open(options \\ %{}) do
+    SlackAPI.request("conversations.open", options)
+    |> SlackAPI.render_response()
+  end
+end

--- a/test/fixtures/vcr_cassettes/conversations/open/invalid_auth.json
+++ b/test/fixtures/vcr_cassettes/conversations/open/invalid_auth.json
@@ -1,0 +1,44 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json",
+        "Authorization": "Bearer blah",
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/conversations.open"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":false,\"error\":\"invalid_auth\"}",
+      "headers": {
+        "date": "Fri, 28 May 2021 16:31:46 GMT",
+        "server": "Apache",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "access-control-allow-origin": "*",
+        "x-slack-backend": "r",
+        "x-xss-protection": "0",
+        "x-slack-req-id": "fe4dc8bcdc297cb190694b06bd7ee27f",
+        "vary": "Accept-Encoding",
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "9",
+        "x-backend": "main_normal main_canary_with_overflow main_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-1tep",
+        "x-via": "envoy-www-iad-98om, haproxy-edge-iad-3wy0",
+        "x-slack-shared-secret-outcome": "shared-secret",
+        "via": "envoy-www-iad-98om",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixtures/vcr_cassettes/conversations/open/successful.json
+++ b/test/fixtures/vcr_cassettes/conversations/open/successful.json
@@ -1,0 +1,48 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/conversations.open?token=***&user=U052YB8KQ&users=U052YB8KQ"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":true,\"no_op\":true,\"already_open\":true,\"channel\":{\"id\":\"D01NBN0GSQZ\"}}",
+      "headers": {
+        "date": "Fri, 28 May 2021 16:31:43 GMT",
+        "server": "Apache",
+        "x-xss-protection": "0",
+        "pragma": "no-cache",
+        "cache-control": "private, no-cache, no-store, must-revalidate",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "x-slack-req-id": "8b34acc90d9df941eb3dc84b86f1e3f8",
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "x-slack-backend": "r",
+        "x-oauth-scopes": "users:read,team:read,channels:manage,im:write",
+        "x-accepted-oauth-scopes": "channels:write,groups:write,mpim:write,im:write,post",
+        "expires": "Mon, 26 Jul 1997 05:00:00 GMT",
+        "vary": "Accept-Encoding",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "22",
+        "x-backend": "main_normal main_canary_with_overflow main_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-rcjv",
+        "x-via": "envoy-www-iad-nzqs, haproxy-edge-iad-3wy0",
+        "x-slack-shared-secret-outcome": "shared-secret",
+        "via": "envoy-www-iad-nzqs",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/juvet/slack_api/conversations_test.exs
+++ b/test/juvet/slack_api/conversations_test.exs
@@ -1,0 +1,37 @@
+defmodule Juvet.SlackAPI.ConversationsTest do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  alias Juvet.SlackAPI
+
+  setup_all do
+    HTTPoison.start()
+  end
+
+  setup do
+    {:ok, users: ["USER1"], token: "TOKEN"}
+  end
+
+  describe "SlackAPI.Conversations.open/1" do
+    test "returns the channel id", %{users: users, token: token} do
+      use_cassette "conversations/open/successful" do
+        assert {:ok, response} =
+                 SlackAPI.Conversations.open(%{users: users, token: token})
+
+        assert response[:channel][:id]
+      end
+    end
+
+    test "returns an error from an unsuccessful API call", %{
+      users: users,
+      token: token
+    } do
+      use_cassette "conversations/open/invalid_auth" do
+        assert {:error, response} =
+                 SlackAPI.Conversations.open(%{users: users, token: token})
+
+        assert response[:error] == "invalid_auth"
+      end
+    end
+  end
+end

--- a/test/support/mix/tasks/record.ex
+++ b/test/support/mix/tasks/record.ex
@@ -11,7 +11,13 @@ defmodule Mix.Tasks.Record do
       |> Enum.map(fn arg -> String.split(arg, ":") end)
       |> Enum.into(%{}, fn [a, b] -> {String.trim_trailing(a, ":"), b} end)
 
-    methods = ["im.open", "rtm.connect", "team.info", "users.info"]
+    methods = [
+      "conversations.open",
+      "im.open",
+      "rtm.connect",
+      "team.info",
+      "users.info"
+    ]
 
     Enum.each(methods, fn method_name ->
       delete_cassettes(method_name)


### PR DESCRIPTION
This PR adds a wrapper around the [conversations.open](https://api.slack.com/methods/conversations.open) API endpoint on Slack.

This includes necessary changes to convert array parameters to the wrapped method to a string of comma separated values.