### PR TITLE
Wrap chat.postMessage api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ mix test
 You can re-record the responses from Slack with the following mix command:
 
 ```
-MIX_ENV=test mix record token:<slack token here> user:<slack user id here> users:<slack user id here>,<another slack user id here>
+MIX_ENV=test mix record token:<slack token here> channel:<slack channel id here> text:<Welcome from Juvet!> user:<slack user id here> users:<slack user id here>,<another slack user id here>
 ```
 
 You can create a Slack token for any of your teams [here](https://api.slack.com/custom-integrations/legacy-tokens)/.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -1,0 +1,27 @@
+defmodule Juvet.SlackAPI.Chat do
+  @moduledoc """
+  A wrapper around the chat methods on the Slack API.
+  """
+
+  alias Juvet.SlackAPI
+
+  @doc """
+  Creates a new message and sends it to the channel specified.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    message: {
+      text: "Hello World"
+    }
+  } = Juvet.SlackAPI.Chat.post_message(%{token: token, channel: channel, text: text})
+  """
+
+  def post_message(options \\ %{}) do
+    SlackAPI.request("chat.postMessage", options)
+    |> SlackAPI.render_response()
+  end
+end

--- a/test/fixtures/vcr_cassettes/chat/postmessage/invalid_auth.json
+++ b/test/fixtures/vcr_cassettes/chat/postmessage/invalid_auth.json
@@ -1,0 +1,44 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json",
+        "Authorization": "Bearer blah",
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/chat.postMessage"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":false,\"error\":\"invalid_auth\"}",
+      "headers": {
+        "date": "Fri, 28 May 2021 19:24:12 GMT",
+        "server": "Apache",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "access-control-allow-origin": "*",
+        "x-slack-backend": "r",
+        "x-xss-protection": "0",
+        "x-slack-req-id": "444b4f98cb88e09a924db74570871f77",
+        "vary": "Accept-Encoding",
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "3",
+        "x-backend": "main_normal main_canary_with_overflow main_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-pwog",
+        "x-via": "envoy-www-iad-nzda, haproxy-edge-iad-8o74",
+        "x-slack-shared-secret-outcome": "shared-secret",
+        "via": "envoy-www-iad-nzda",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixtures/vcr_cassettes/chat/postmessage/successful.json
+++ b/test/fixtures/vcr_cassettes/chat/postmessage/successful.json
@@ -1,0 +1,48 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/chat.postMessage?channel=C04ASG29V&text=Hello+from+Juvet&token=***&user=U052YB8KQ&users=U052YB8KQ"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":true,\"channel\":\"C04ASG29V\",\"ts\":\"1622229848.000100\",\"message\":{\"bot_id\":\"B01MZ3JQYP4\",\"type\":\"message\",\"text\":\"Hello from Juvet\",\"user\":\"U01MSA502JJ\",\"ts\":\"1622229848.000100\",\"team\":\"T04ASG29D\",\"bot_profile\":{\"id\":\"B01MZ3JQYP4\",\"deleted\":false,\"name\":\"Tatsu Next\",\"updated\":1613150623,\"app_id\":\"A01JVR00QJX\",\"icons\":{\"image_36\":\"https:\\/\\/a.slack-edge.com\\/80588\\/img\\/plugins\\/app\\/bot_36.png\",\"image_48\":\"https:\\/\\/a.slack-edge.com\\/80588\\/img\\/plugins\\/app\\/bot_48.png\",\"image_72\":\"https:\\/\\/a.slack-edge.com\\/80588\\/img\\/plugins\\/app\\/service_72.png\"},\"team_id\":\"T04ASG29D\"}}}",
+      "headers": {
+        "date": "Fri, 28 May 2021 19:24:08 GMT",
+        "server": "Apache",
+        "x-xss-protection": "0",
+        "pragma": "no-cache",
+        "cache-control": "private, no-cache, no-store, must-revalidate",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "x-slack-req-id": "337eebf87a9a9184e59d683c518ac0a3",
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "x-slack-backend": "r",
+        "x-oauth-scopes": "users:read,team:read,channels:manage,im:write,chat:write,chat:write.public",
+        "x-accepted-oauth-scopes": "chat:write",
+        "expires": "Mon, 26 Jul 1997 05:00:00 GMT",
+        "vary": "Accept-Encoding",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "66",
+        "x-backend": "main_normal main_canary_with_overflow main_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-xii8",
+        "x-via": "envoy-www-iad-rgup, haproxy-edge-iad-8o74",
+        "x-slack-shared-secret-outcome": "shared-secret",
+        "via": "envoy-www-iad-rgup",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/juvet/slack_api/chat_test.exs
+++ b/test/juvet/slack_api/chat_test.exs
@@ -1,0 +1,46 @@
+defmodule Juvet.SlackAPI.ChatTest do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  alias Juvet.SlackAPI
+
+  setup_all do
+    HTTPoison.start()
+  end
+
+  setup do
+    {:ok, channel: "CHANNEL1", text: "Hello from Juvet", token: "TOKEN"}
+  end
+
+  describe "SlackAPI.Chat.post_message/1" do
+    test "returns the message", %{channel: channel, text: text, token: token} do
+      use_cassette "chat/postMessage/successful" do
+        assert {:ok, response} =
+                 SlackAPI.Chat.post_message(%{
+                   channel: channel,
+                   text: text,
+                   token: token
+                 })
+
+        assert response[:message][:text] == "Hello from Juvet"
+      end
+    end
+
+    test "returns an error from an unsuccessful API call", %{
+      channel: channel,
+      text: text,
+      token: token
+    } do
+      use_cassette "chat/postMessage/invalid_auth" do
+        assert {:error, response} =
+                 SlackAPI.Chat.post_message(%{
+                   channel: channel,
+                   text: text,
+                   token: token
+                 })
+
+        assert response[:error] == "invalid_auth"
+      end
+    end
+  end
+end

--- a/test/support/mix/tasks/record.ex
+++ b/test/support/mix/tasks/record.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Record do
       |> Enum.into(%{}, fn [a, b] -> {String.trim_trailing(a, ":"), b} end)
 
     methods = [
+      "chat.postMessage",
       "conversations.open",
       "im.open",
       "rtm.connect",


### PR DESCRIPTION
This PR adds a wrapper around the [chat.postMessage](https://api.slack.com/methods/chat.postMessage) API endpoint on Slack.