### PR TITLE
Route Runner

### DIFF
--- a/lib/juvet.ex
+++ b/lib/juvet.ex
@@ -197,6 +197,22 @@ defmodule Juvet do
   end
 
   @doc """
+  Routes a call to a path through middleware and returns a `RunContext` result
+
+  * `:path` - A `String` that represents a path with the pattern of `controller#action` (e.g. `"users#edit"`)
+  * `:context` - A `Map` of values that should be passed to the middleware
+
+  ## Example
+
+  ```
+  Juvet.route("home#index", %{team: team, user: user})
+  ```
+  """
+  def route(path, context \\ %{}) do
+    Juvet.Runner.route(path, context)
+  end
+
+  @doc """
   A shortcut function that creates a bot process (using `create_bot!/1`) and documents (using `connect_bot`)
   that the bot is connected to the specified platform.
 

--- a/lib/juvet.ex
+++ b/lib/juvet.ex
@@ -94,7 +94,14 @@ defmodule Juvet do
 
   @doc false
   def start(_types, _args) do
-    Juvet.BotFactory.start_link(Application.get_all_env(:juvet))
+    Juvet.BotFactory.start_link(configuration())
+  end
+
+  @doc """
+  Returns the configuration configured for Juvet within the `Application`
+  """
+  def configuration do
+    Application.get_all_env(:juvet)
   end
 
   @doc """

--- a/lib/juvet/endpoint_router.ex
+++ b/lib/juvet/endpoint_router.ex
@@ -7,7 +7,7 @@ defmodule Juvet.EndpointRouter do
   """
 
   use Plug.Router
-  use Juvet.SlackEndpointRouter, config: Application.get_all_env(:juvet)
+  use Juvet.SlackEndpointRouter, config: Juvet.configuration()
 
   plug(Plug.Logger)
   plug(:match)

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -2,6 +2,6 @@ defmodule Juvet.Middleware do
   def group(_name) do
     # TODO: Eventually this will be retrieved from the Router and filtered by the group_name
 
-    [{Juvet.Middleware.ActionRunner}]
+    [{Juvet.Middleware.ActionGenerator}]
   end
 end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -1,0 +1,7 @@
+defmodule Juvet.Middleware do
+  def group(_name) do
+    # TODO: Eventually this will be retrieved from the Router and filtered by the group_name
+
+    [{Juvet.Middleware.ActionRunner}]
+  end
+end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -2,6 +2,6 @@ defmodule Juvet.Middleware do
   def group(_name) do
     # TODO: Eventually this will be retrieved from the Router and filtered by the group_name
 
-    [{Juvet.Middleware.ActionGenerator}]
+    [{Juvet.Middleware.ActionGenerator}, {Juvet.Middleware.ActionRunner}]
   end
 end

--- a/lib/juvet/middleware/action_generator.ex
+++ b/lib/juvet/middleware/action_generator.ex
@@ -9,11 +9,9 @@ defmodule Juvet.Middleware.ActionGenerator do
     [controller_prefix, action_name] =
       String.split(path, "#", parts: 2, trim: true)
 
-    controller =
-      "#{controller_prefix}_controller"
-      |> Macro.camelize()
-      |> String.to_atom()
+    controller_name =
+      "Elixir.#{Macro.camelize("#{controller_prefix}_controller")}"
 
-    {controller, String.to_atom(action_name)}
+    {String.to_atom(controller_name), String.to_atom(action_name)}
   end
 end

--- a/lib/juvet/middleware/action_generator.ex
+++ b/lib/juvet/middleware/action_generator.ex
@@ -14,6 +14,6 @@ defmodule Juvet.Middleware.ActionGenerator do
       |> Macro.camelize()
       |> String.to_atom()
 
-    {controller, action_name}
+    {controller, String.to_atom(action_name)}
   end
 end

--- a/lib/juvet/middleware/action_generator.ex
+++ b/lib/juvet/middleware/action_generator.ex
@@ -1,0 +1,19 @@
+defmodule Juvet.Middleware.ActionGenerator do
+  def call(%{path: path} = context) do
+    {:ok, Map.put_new(context, :action, generate_action(path))}
+  end
+
+  def call(_context), do: {:error, "`path` missing in the `context`"}
+
+  defp generate_action(path) do
+    [controller_prefix, action_name] =
+      String.split(path, "#", parts: 2, trim: true)
+
+    controller =
+      "#{controller_prefix}_controller"
+      |> Macro.camelize()
+      |> String.to_atom()
+
+    {controller, action_name}
+  end
+end

--- a/lib/juvet/middleware/action_generator.ex
+++ b/lib/juvet/middleware/action_generator.ex
@@ -10,7 +10,8 @@ defmodule Juvet.Middleware.ActionGenerator do
       String.split(path, "#", parts: 2, trim: true)
 
     controller_name =
-      "Elixir.#{Macro.camelize("#{controller_prefix}_controller")}"
+      String.split("elixir.#{controller_prefix}_controller", ".")
+      |> Enum.map_join(".", fn part -> Macro.camelize(part) end)
 
     {String.to_atom(controller_name), String.to_atom(action_name)}
   end

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -3,9 +3,14 @@ defmodule Juvet.Middleware.ActionRunner do
     m = elem(action, 0)
     f = elem(action, 1)
 
-    apply(m, f, [context])
-
-    {:ok, context}
+    try do
+      apply(m, f, [context])
+    rescue
+      UndefinedFunctionError -> {:error, "`#{m}.#{f}/1` is not defined"}
+    else
+      _ ->
+        {:ok, context}
+    end
   end
 
   def call(_context), do: {:error, "`action` missing in the `context`"}

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -1,0 +1,12 @@
+defmodule Juvet.Middleware.ActionRunner do
+  def call(%{action: action} = context) do
+    m = elem(action, 0)
+    f = elem(action, 1)
+
+    apply(m, f, [context])
+
+    {:ok, context}
+  end
+
+  def call(_context), do: {:error, "`action` missing in the `context`"}
+end

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -1,0 +1,3 @@
+defmodule Juvet.Middleware.ActionRunner do
+  def call(context), do: context
+end

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -1,3 +1,0 @@
-defmodule Juvet.Middleware.ActionRunner do
-  def call(context), do: {:ok, context}
-end

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -1,3 +1,3 @@
 defmodule Juvet.Middleware.ActionRunner do
-  def call(context), do: context
+  def call(context), do: {:ok, context}
 end

--- a/lib/juvet/middleware_processor.ex
+++ b/lib/juvet/middleware_processor.ex
@@ -1,0 +1,9 @@
+defmodule Juvet.MiddlewareProcessor do
+  def process(context) do
+    Enum.reduce(context.middleware, context, &process/2)
+  end
+
+  def process(middleware, context) do
+    apply(elem(middleware, 0), :call, [context])
+  end
+end

--- a/lib/juvet/middleware_processor.ex
+++ b/lib/juvet/middleware_processor.ex
@@ -1,6 +1,12 @@
 defmodule Juvet.MiddlewareProcessor do
   def process(context) do
-    Enum.reduce(context.middleware, context, &process/2)
+    Enum.reduce_while(context.middleware, {:ok, context}, fn middleware,
+                                                             {:ok, result} ->
+      case process(middleware, result) do
+        {:ok, ctx} -> {:cont, {:ok, ctx}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
   end
 
   def process(middleware, context) do

--- a/lib/juvet/runner.ex
+++ b/lib/juvet/runner.ex
@@ -1,0 +1,11 @@
+defmodule Juvet.Runner do
+  alias Juvet.{Middleware, MiddlewareProcessor}
+
+  def route(path, context \\ %{}) do
+    %{configuration: Juvet.configuration()}
+    |> Map.merge(%{path: path})
+    |> Map.merge(context)
+    |> Map.merge(%{middleware: Middleware.group(:partial)})
+    |> MiddlewareProcessor.process()
+  end
+end

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -17,7 +17,7 @@ defmodule Juvet.Middleware.ActionGeneratorTest do
            context: context
          } do
       assert {:ok, ctx} = Juvet.Middleware.ActionGenerator.call(context)
-      assert ctx[:action] == {:TestController, :action}
+      assert ctx[:action] == {:"Elixir.TestController", :action}
     end
   end
 end

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -19,5 +19,14 @@ defmodule Juvet.Middleware.ActionGeneratorTest do
       assert {:ok, ctx} = Juvet.Middleware.ActionGenerator.call(context)
       assert ctx[:action] == {:"Elixir.TestController", :action}
     end
+
+    test "handle namespacing in the controller path" do
+      assert {:ok, context} =
+               Juvet.Middleware.ActionGenerator.call(%{
+                 path: "namespace.test#action"
+               })
+
+      assert context[:action] == {:"Elixir.Namespace.TestController", :action}
+    end
   end
 end

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -1,0 +1,23 @@
+defmodule Juvet.Middleware.ActionGeneratorTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.Middleware.ActionGenerator.call/1" do
+    setup do
+      [context: %{path: "test#action"}]
+    end
+
+    test "returns an error if the context does not contain a path" do
+      result = Juvet.Middleware.ActionGenerator.call(%{})
+
+      assert result == {:error, "`path` missing in the `context`"}
+    end
+
+    test "returns an endpoint Tuple with the controller and action",
+         %{
+           context: context
+         } do
+      assert {:ok, ctx} = Juvet.Middleware.ActionGenerator.call(context)
+      assert ctx[:action] == {:TestController, "action"}
+    end
+  end
+end

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -17,7 +17,7 @@ defmodule Juvet.Middleware.ActionGeneratorTest do
            context: context
          } do
       assert {:ok, ctx} = Juvet.Middleware.ActionGenerator.call(context)
-      assert ctx[:action] == {:TestController, "action"}
+      assert ctx[:action] == {:TestController, :action}
     end
   end
 end

--- a/test/juvet/middleware/action_runner_test.exs
+++ b/test/juvet/middleware/action_runner_test.exs
@@ -1,0 +1,38 @@
+defmodule Juvet.Middleware.ActionRunnerTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestController do
+    def action(context) do
+      send(context.pid, :called_controller)
+    end
+  end
+
+  describe "Juvet.Middleware.ActionRunner.call/1" do
+    setup do
+      [
+        context: %{
+          action:
+            {:"Elixir.Juvet.Middleware.ActionRunnerTest.TestController",
+             :action}
+        }
+      ]
+    end
+
+    test "returns an error if the context does not contain an action" do
+      result = Juvet.Middleware.ActionRunner.call(%{})
+
+      assert result == {:error, "`action` missing in the `context`"}
+    end
+
+    test "calls the controller module and action with the context", %{
+      context: context
+    } do
+      assert {:ok, ctx} =
+               Juvet.Middleware.ActionRunner.call(
+                 Map.merge(context, %{pid: self()})
+               )
+
+      assert_received :called_controller
+    end
+  end
+end

--- a/test/juvet/middleware/action_runner_test.exs
+++ b/test/juvet/middleware/action_runner_test.exs
@@ -24,6 +24,13 @@ defmodule Juvet.Middleware.ActionRunnerTest do
       assert result == {:error, "`action` missing in the `context`"}
     end
 
+    test "returns an error if the controller action could not be called" do
+      result =
+        Juvet.Middleware.ActionRunner.call(%{action: {:TestController, :action}})
+
+      assert result == {:error, "`TestController.action/1` is not defined"}
+    end
+
     test "calls the controller module and action with the context", %{
       context: context
     } do

--- a/test/juvet/middleware_processor_test.exs
+++ b/test/juvet/middleware_processor_test.exs
@@ -1,0 +1,22 @@
+defmodule Juvet.MiddlewareProcessorTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.Middleware.process/1" do
+    defmodule TestMiddleware1 do
+      def call(context) do
+        Map.put(context, :middleware1, "was here")
+      end
+    end
+
+    setup do
+      [context: %{middleware: [{TestMiddleware1}]}]
+    end
+
+    test "returns the context modifications that occurred", %{context: context} do
+      context = Juvet.MiddlewareProcessor.process(context)
+
+      assert Map.has_key?(context, :middleware1)
+      assert Map.fetch!(context, :middleware1) == "was here"
+    end
+  end
+end

--- a/test/juvet/middleware_processor_test.exs
+++ b/test/juvet/middleware_processor_test.exs
@@ -2,21 +2,36 @@ defmodule Juvet.MiddlewareProcessorTest do
   use ExUnit.Case, async: true
 
   describe "Juvet.Middleware.process/1" do
-    defmodule TestMiddleware1 do
+    defmodule ErrorMiddleware do
+      def call(_context) do
+        {:error, "There was an error"}
+      end
+    end
+
+    defmodule TestMiddleware do
       def call(context) do
-        Map.put(context, :middleware1, "was here")
+        {:ok, Map.put(context, :middleware1, "was here")}
       end
     end
 
     setup do
-      [context: %{middleware: [{TestMiddleware1}]}]
+      [context: %{middleware: [{TestMiddleware}]}]
     end
 
     test "returns the context modifications that occurred", %{context: context} do
-      context = Juvet.MiddlewareProcessor.process(context)
+      {:ok, context} = Juvet.MiddlewareProcessor.process(context)
 
       assert Map.has_key?(context, :middleware1)
       assert Map.fetch!(context, :middleware1) == "was here"
+    end
+
+    test "returns an error if there was an error", %{context: context} do
+      {:error, error} =
+        Juvet.MiddlewareProcessor.process(
+          Map.merge(context, %{middleware: [{ErrorMiddleware}]})
+        )
+
+      assert error == "There was an error"
     end
   end
 end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -1,14 +1,18 @@
 defmodule Juvet.RunnerTest do
   use ExUnit.Case, async: true
 
-  describe "Juvet.Runner.route/2" do
-    defmodule ControllerController do
-      def action do
-      end
+  defmodule TestController do
+    def action(%{pid: pid}) do
+      send(pid, :called_controller)
     end
 
+    def action(_context) do
+    end
+  end
+
+  describe "Juvet.Runner.route/2" do
     setup do
-      [path: "controller#action"]
+      [path: "juvet.runner_test.test#action"]
     end
 
     test "adds the configuration to the context", %{path: path} do
@@ -33,7 +37,13 @@ defmodule Juvet.RunnerTest do
       {:ok, context} = Juvet.Runner.route(path)
 
       assert Map.fetch!(context, :action) ==
-               {:"Elixir.ControllerController", :action}
+               {:"Elixir.Juvet.RunnerTest.TestController", :action}
+    end
+
+    test "calls the controller module and action from the path", %{path: path} do
+      {:ok, _context} = Juvet.Runner.route(path, %{pid: self()})
+
+      assert_received :called_controller
     end
   end
 end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -32,7 +32,7 @@ defmodule Juvet.RunnerTest do
     test "adds the route to the context based on the path", %{path: path} do
       {:ok, context} = Juvet.Runner.route(path)
 
-      assert Map.fetch!(context, :action) == {:ControllerController, "action"}
+      assert Map.fetch!(context, :action) == {:ControllerController, :action}
     end
   end
 end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -1,0 +1,38 @@
+defmodule Juvet.RunnerTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.Runner.route/2" do
+    defmodule ControllerController do
+      def action do
+      end
+    end
+
+    setup do
+      [path: "controller#action"]
+    end
+
+    test "adds the configuration to the context", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path)
+
+      assert Map.fetch!(context, :configuration) == Juvet.configuration()
+    end
+
+    test "adds the current values in the context", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path, %{blah: "bleh"})
+
+      assert Map.fetch!(context, :blah) == "bleh"
+    end
+
+    test "adds the path to the context", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path)
+
+      assert Map.fetch!(context, :path) == path
+    end
+
+    test "adds the route to the context based on the path", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path)
+
+      assert Map.fetch!(context, :action) == {:ControllerController, "action"}
+    end
+  end
+end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -32,7 +32,8 @@ defmodule Juvet.RunnerTest do
     test "adds the route to the context based on the path", %{path: path} do
       {:ok, context} = Juvet.Runner.route(path)
 
-      assert Map.fetch!(context, :action) == {:ControllerController, :action}
+      assert Map.fetch!(context, :action) ==
+               {:"Elixir.ControllerController", :action}
     end
   end
 end

--- a/test/juvet_test.exs
+++ b/test/juvet_test.exs
@@ -48,4 +48,10 @@ defmodule Juvet.JuvetTest do
       assert List.first(List.first(platforms).messages) == %{team_id: "T12345"}
     end
   end
+
+  describe "Juvet.configuration/0" do
+    test "returns the configuration specified in the application" do
+      assert Juvet.configuration() == Application.get_all_env(:juvet)
+    end
+  end
 end

--- a/test/support/configuration_helpers.ex
+++ b/test/support/configuration_helpers.ex
@@ -16,7 +16,7 @@ defmodule Juvet.ConfigurationHelpers do
   end
 
   def setup_reset_config_on_exit(_context) do
-    config = Application.get_all_env(:juvet)
+    config = Juvet.configuration()
 
     on_exit(fn ->
       reset_config(config)


### PR DESCRIPTION
This PR introduces a way for a client application to route to a specified controller and action.

The client application can run a Juvet "request" through the following:

```
defmodule NewTeam do
  def welcome_team(user, team) do
    Juvet.route("welcome#team", %{team: team, user: user})
  end
end
```

This will run the "request" through some basic middleware (hard-coded for now) that will generate an action from the path and then call that action using `apply`. It's that simple.

If the middleware succeeds, the `Juvet.route/2` function will return an `{:ok, context}` tuple that contains all the modifications to the context from running the route. If there are any issues with running the middleware, the function will return an `{:error, reason}` tuple.