### PR TITLE
Slack Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ config :juvet,
   bot: MyBot,
   slack: [
     actions_endpoint: "/slack/actions",
+    commands_endpoint: "/slack/commands",
     events_endpoint: "/slack/events"
   ]
 ```

--- a/README.md
+++ b/README.md
@@ -130,26 +130,21 @@ config :juvet,
 
 ### Mount Router
 
-The client application that is using Juvet can use the router from your client application. You just need to mount the `Juvet.EndpointRouter`.
+The client application that is using Juvet can use the router from your client application. You just need to mount the `Juvet.Plug`.
 
 #### Mounting in Phoenix
 
-The router can be mounted inside the Phoenix router with `[Phoenix.Router.forward/4](https://hexdocs.pm/phoenix/Phoenix.Router.html#forward/4)`.
+The router can be mounted inside the Phoenix endpoint by just adding:
 
 ```
-defmodule MyPhoenixAppWeb.Router do
-  use MyPhoenixAppWeb, :router
+# lib/my_phoenix_app_web/endpoint.ex
 
-  pipeline :mounted_apps do
-    plug :accepts, ["html"]
-    plug :put_secure_browser_headers
-  end
+defmodule MyPhoenixAppWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :my_phoenix_app
 
-  scope path: "/slack" do
-    pipe_through :mounted_apps
+  # ...
 
-    forward "/", Juvet.EndpointRouter
-  end
+  plug Juvet.Plug
 end
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :juvet,
   slack: [
+    commands_endpoint: "/slack/commands",
     events_endpoint: "/slack/events"
   ]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :plug, :validate_header_keys_during_test, false
+
 config :exvcr,
   vcr_cassette_library_dir: "test/fixtures/vcr_cassettes",
   custom_cassette_library_dir: "test/fixtures/custom_cassettes",

--- a/lib/juvet.ex
+++ b/lib/juvet.ex
@@ -31,6 +31,7 @@ defmodule Juvet do
     bot: MyBot,
     slack: [
       actions_endpoint: "/slack/actions",
+      commands_endpoint: "/slack/commands",
       events_endpoint: "/slack/events"
     ]
   ```

--- a/lib/juvet/cache_body_reader.ex
+++ b/lib/juvet/cache_body_reader.ex
@@ -5,14 +5,9 @@ defmodule Juvet.CacheBodyReader do
     {:ok, body, conn}
   end
 
-  defp put_raw_body(%Plug.Conn{private: %{juvet: juvet}} = conn, body) do
-    juvet = Map.merge(juvet, raw_body_map(body))
-
-    Plug.Conn.put_private(conn, :juvet, juvet)
+  defp put_raw_body(%Plug.Conn{} = conn, body) do
+    Juvet.Conn.put_private(conn, raw_body_map(body))
   end
-
-  defp put_raw_body(conn, body),
-    do: Plug.Conn.put_private(conn, :juvet, raw_body_map(body))
 
   defp raw_body_map(body) do
     opts = %{raw_body: nil}

--- a/lib/juvet/cache_body_reader.ex
+++ b/lib/juvet/cache_body_reader.ex
@@ -1,0 +1,22 @@
+defmodule Juvet.CacheBodyReader do
+  def read_body(conn, opts) do
+    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+    conn = put_raw_body(conn, body)
+    {:ok, body, conn}
+  end
+
+  defp put_raw_body(%Plug.Conn{private: %{juvet: juvet}} = conn, body) do
+    juvet = Map.merge(juvet, raw_body_map(body))
+
+    Plug.Conn.put_private(conn, :juvet, juvet)
+  end
+
+  defp put_raw_body(conn, body),
+    do: Plug.Conn.put_private(conn, :juvet, raw_body_map(body))
+
+  defp raw_body_map(body) do
+    opts = %{raw_body: nil}
+
+    update_in(opts[:raw_body], &[body | &1 || []])
+  end
+end

--- a/lib/juvet/config.ex
+++ b/lib/juvet/config.ex
@@ -12,6 +12,7 @@ defmodule Juvet.Config do
     bot: MyBot,
     slack: [
       actions_endpoint: "/slack/actions",
+      commands_endpoint: "/slack/commands",
       events_endpoint: "/slack/events"
     ]
   ```

--- a/lib/juvet/configuration_error.ex
+++ b/lib/juvet/configuration_error.ex
@@ -1,0 +1,10 @@
+defmodule Juvet.ConfigurationError do
+  @moduledoc """
+  Exception raised when there is an issue with the Juvet configuration.
+  """
+  defexception message: "Configuration for Juvet is invalid"
+
+  def exception(message) do
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/juvet/conn.ex
+++ b/lib/juvet/conn.ex
@@ -1,0 +1,16 @@
+defmodule Juvet.Conn do
+  @moduledoc """
+  Functions to make working with a `Plug.Conn` easier and more consistent.
+  """
+
+  @private_key :juvet
+
+  def put_private(%Plug.Conn{} = conn, value) when is_map(value) do
+    current = get_private(conn, %{})
+    Plug.Conn.put_private(conn, @private_key, Map.merge(current, value))
+  end
+
+  def get_private(%Plug.Conn{private: private}, default \\ nil) do
+    private[@private_key] || default
+  end
+end

--- a/lib/juvet/conn.ex
+++ b/lib/juvet/conn.ex
@@ -13,4 +13,6 @@ defmodule Juvet.Conn do
   def get_private(%Plug.Conn{private: private}, default \\ nil) do
     private[@private_key] || default
   end
+
+  def private_key, do: @private_key
 end

--- a/lib/juvet/gregorian_date_time.ex
+++ b/lib/juvet/gregorian_date_time.ex
@@ -1,0 +1,16 @@
+defmodule Juvet.GregorianDateTime do
+  # TODO: Could use Elixir native methods if runtime is uopdated: https://hexdocs.pm/elixir/1.13.1/DateTime.html#from_gregorian_seconds/3
+  @unix_gregorian_offset 62_167_219_200
+
+  def to_seconds(date_time \\ NaiveDateTime.utc_now()) do
+    timestamp =
+      date_time
+      |> convert_to_calendar()
+      |> :calendar.datetime_to_gregorian_seconds()
+
+    timestamp - @unix_gregorian_offset
+  end
+
+  defp convert_to_calendar(%NaiveDateTime{} = date_time),
+    do: date_time |> NaiveDateTime.to_erl()
+end

--- a/lib/juvet/invalid_request_error.ex
+++ b/lib/juvet/invalid_request_error.ex
@@ -1,0 +1,10 @@
+defmodule Juvet.InvalidRequestError do
+  @moduledoc """
+  Exception raised when a request is invalid that comes into Juvet.
+  """
+  defexception message: "Invalid request"
+
+  def exception(message) do
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -10,7 +10,8 @@ defmodule Juvet.Middleware do
     [
       {Juvet.Middleware.ParseRequest},
       {Juvet.Middleware.IdentifyRequest},
-      {Juvet.Middleware.Slack.VerifyRequest}
+      {Juvet.Middleware.Slack.VerifyRequest},
+      {Juvet.Middleware.RouteRequest}
     ]
   end
 end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -9,7 +9,8 @@ defmodule Juvet.Middleware do
   def group(:all) do
     [
       {Juvet.Middleware.ParseRequest},
-      {Juvet.Middleware.IdentifyRequest}
+      {Juvet.Middleware.IdentifyRequest},
+      {Juvet.Middleware.Slack.VerifyRequest}
     ]
   end
 end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -12,6 +12,6 @@ defmodule Juvet.Middleware do
       {Juvet.Middleware.IdentifyRequest},
       {Juvet.Middleware.Slack.VerifyRequest},
       {Juvet.Middleware.RouteRequest}
-    ]
+    ] ++ group(:partial)
   end
 end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -1,7 +1,15 @@
 defmodule Juvet.Middleware do
-  def group(_name) do
-    # TODO: Eventually this will be retrieved from the Router and filtered by the group_name
+  # TODO: Eventually the middleware grouping will be retrieved from the Router and filtered by the group_name
+  # For now, we hardcode
 
+  def group(:partial) do
     [{Juvet.Middleware.ActionGenerator}, {Juvet.Middleware.ActionRunner}]
+  end
+
+  def group(:all) do
+    [
+      {Juvet.Middleware.ParseRequest},
+      {Juvet.Middleware.IdentifyRequest}
+    ]
   end
 end

--- a/lib/juvet/middleware/identify_request.ex
+++ b/lib/juvet/middleware/identify_request.ex
@@ -1,11 +1,15 @@
 defmodule Juvet.Middleware.IdentifyRequest do
-  def call(
-        %{request: %{headers: [{"x-slack-signature", _} | _]} = request} =
-          context
-      ) do
-    request = %{request | platform: :slack}
+  alias Juvet.Router.Request
 
-    {:ok, %{context | request: request}}
+  def call(%{request: request} = context) do
+    case Request.get_header(request, "x-slack-signature") do
+      [] ->
+        {:ok, context}
+
+      [_] ->
+        request = %{request | platform: :slack}
+        {:ok, %{context | request: request}}
+    end
   end
 
   def call(context), do: {:ok, context}

--- a/lib/juvet/middleware/identify_request.ex
+++ b/lib/juvet/middleware/identify_request.ex
@@ -1,0 +1,12 @@
+defmodule Juvet.Middleware.IdentifyRequest do
+  def call(
+        %{request: %{headers: [{"x-slack-signature", _} | _]} = request} =
+          context
+      ) do
+    request = %{request | platform: :slack}
+
+    {:ok, %{context | request: request}}
+  end
+
+  def call(context), do: {:ok, context}
+end

--- a/lib/juvet/middleware/parse_request.ex
+++ b/lib/juvet/middleware/parse_request.ex
@@ -1,0 +1,9 @@
+defmodule Juvet.Middleware.ParseRequest do
+  def call(%{conn: conn} = context) do
+    {:ok, Map.put_new(context, :request, generate_request(conn))}
+  end
+
+  def call(context), do: {:ok, context}
+
+  defp generate_request(conn), do: Juvet.Router.Request.new(conn)
+end

--- a/lib/juvet/middleware/request.ex
+++ b/lib/juvet/middleware/request.ex
@@ -1,0 +1,25 @@
+defmodule Juvet.Middleware.Request do
+  defstruct headers: [],
+            host: nil,
+            method: nil,
+            params: nil,
+            path: nil,
+            port: nil,
+            query_string: nil,
+            scheme: nil,
+            status: nil
+
+  def new(conn) do
+    %__MODULE__{
+      headers: conn.req_headers,
+      host: conn.host,
+      method: conn.method,
+      params: conn.params,
+      path: conn.request_path,
+      port: conn.port,
+      query_string: conn.query_string,
+      scheme: conn.scheme,
+      status: conn.status
+    }
+  end
+end

--- a/lib/juvet/middleware/route_request.ex
+++ b/lib/juvet/middleware/route_request.ex
@@ -1,0 +1,59 @@
+defmodule Juvet.Middleware.RouteRequest do
+  alias Juvet.Router
+  alias Juvet.Router.{Request, Route}
+
+  def call(
+        %{
+          configuration: configuration,
+          request: %Request{verified?: true} = request
+        } = context
+      ) do
+    with {:ok, router} <- get_router(configuration) do
+      case Router.find_route(router, request) do
+        {:ok, route} ->
+          {:ok,
+           Map.merge(context, %{
+             path: Route.path(route),
+             route: route
+           })}
+
+        {:error, :not_found} ->
+          {:error,
+           %Juvet.RoutingError{
+             message: "No route found for the request.",
+             request: request
+           }}
+      end
+    else
+      {:error, {:invalid_router, invalid_router}} ->
+        router_name = invalid_router |> to_string |> router_name()
+
+        {:error,
+         %Juvet.ConfigurationError{
+           message:
+             "Router #{router_name} configured in Juvet configuration is not found."
+         }}
+
+      {:error, :missing_router} ->
+        {:error,
+         %Juvet.ConfigurationError{
+           message: "Router missing in Juvet configuration."
+         }}
+    end
+  end
+
+  defp get_router(configuration) do
+    with router when not is_nil(router) <- Keyword.get(configuration, :router) do
+      case Router.exists?(router) do
+        true -> {:ok, router}
+        false -> {:error, {:invalid_router, router}}
+      end
+    else
+      _ ->
+        {:error, :missing_router}
+    end
+  end
+
+  defp router_name("Elixir." <> name), do: name
+  defp router_name(name), do: name
+end

--- a/lib/juvet/middleware/route_request.ex
+++ b/lib/juvet/middleware/route_request.ex
@@ -2,6 +2,14 @@ defmodule Juvet.Middleware.RouteRequest do
   alias Juvet.Router
   alias Juvet.Router.{Request, Route}
 
+  def call(%{request: %Request{verified?: false} = request}),
+    do:
+      {:error,
+       %Juvet.RoutingError{
+         message: "Request was not verified.",
+         request: request
+       }}
+
   def call(
         %{
           configuration: configuration,

--- a/lib/juvet/middleware/slack/verify_request.ex
+++ b/lib/juvet/middleware/slack/verify_request.ex
@@ -54,16 +54,7 @@ defmodule Juvet.Middleware.Slack.VerifyRequest do
   end
 
   defp create_signature(timestamp, raw_body, signing_secret) do
-    "v0=#{
-      :crypto.mac(
-        :hmac,
-        :sha256,
-        signing_secret,
-        "v0:#{timestamp}:#{raw_body}"
-      )
-      |> Base.encode16()
-    }"
-    |> String.downcase()
+    Juvet.SlackSigningSecret.generate(raw_body, signing_secret, timestamp)
   end
 
   defp compare_signature(signature, slack_signature, context) do

--- a/lib/juvet/middleware/slack/verify_request.ex
+++ b/lib/juvet/middleware/slack/verify_request.ex
@@ -74,7 +74,7 @@ defmodule Juvet.Middleware.Slack.VerifyRequest do
   defp compare_signature(true, context), do: request_verified!(context)
 
   defp get_request_raw_body(request) do
-    case get_in(request.private, [:juvet, :raw_body]) do
+    case get_in(request.private, [Juvet.Conn.private_key(), :raw_body]) do
       nil -> {:error, :missing_raw_body}
       raw_body -> {:ok, raw_body}
     end

--- a/lib/juvet/middleware/slack/verify_request.ex
+++ b/lib/juvet/middleware/slack/verify_request.ex
@@ -1,0 +1,115 @@
+defmodule Juvet.Middleware.Slack.VerifyRequest do
+  alias Juvet.GregorianDateTime
+
+  def call(%{request: %{platform: :unknown}} = context), do: {:ok, context}
+
+  def call(
+        %{configuration: configuration, request: %{platform: :slack} = request} =
+          context
+      ) do
+    # Check timestamp staleness, if stale set InvalidRequestError with approriate message
+    # Compare signature, if not valid, set error
+    with {:ok, slack_timestamp} <-
+           get_request_header(request, "x-slack-request-timestamp"),
+         {:ok, slack_signature} <-
+           get_request_header(request, "x-slack-signature"),
+         {:ok, timestamp} <- validate_timestamp(slack_timestamp),
+         {:ok, raw_body} <- get_request_raw_body(request),
+         {:ok, signing_secret} <- get_signing_secret(configuration) do
+      create_signature(timestamp, raw_body, signing_secret)
+      |> compare_signature(slack_signature, context)
+    else
+      {:error, "x-slack-request-timestamp" = header} ->
+        {:error,
+         %Juvet.InvalidRequestError{message: missing_header_message(header)}}
+
+      {:error, "x-slack-signature" = header} ->
+        {:error,
+         %Juvet.InvalidRequestError{message: missing_header_message(header)}}
+
+      {:error, :stale_timestamp} ->
+        {:error, %Juvet.InvalidRequestError{message: "Stale Slack request."}}
+
+      {:error, :missing_raw_body} ->
+        {:error,
+         %Juvet.InvalidRequestError{
+           message:
+             "Request body was empty and could not be verified. Ensure you are caching the request body in a body reader plug."
+         }}
+
+      {:error, :missing_signing_secret} ->
+        {:error,
+         %Juvet.ConfigurationError{
+           message: "Slack signing secret missing in Juvet configuration."
+         }}
+    end
+  end
+
+  def call(context), do: {:ok, context}
+
+  defp create_signature(timestamp, raw_body, signing_secret) do
+    "v0=#{
+      :crypto.mac(
+        :hmac,
+        :sha256,
+        signing_secret,
+        "v0:#{timestamp}:#{raw_body}"
+      )
+      |> Base.encode16()
+    }"
+    |> String.downcase()
+  end
+
+  defp compare_signature(signature, slack_signature, context) do
+    compare_signature(
+      Plug.Crypto.secure_compare(signature, slack_signature),
+      context
+    )
+  end
+
+  defp compare_signature(false, _context),
+    do:
+      {:error,
+       %Juvet.InvalidRequestError{
+         message: "Invalid Slack request. Signature mismatch."
+       }}
+
+  defp compare_signature(true, %{request: request} = context) do
+    request = %{request | verified?: true}
+    {:ok, %{context | request: request}}
+  end
+
+  defp get_request_raw_body(request) do
+    case get_in(request.private, [:juvet, :raw_body]) do
+      nil -> {:error, :missing_raw_body}
+      raw_body -> {:ok, raw_body}
+    end
+  end
+
+  defp get_request_header(request, header) do
+    case Juvet.Router.Request.get_header(request, header) do
+      [value | _] -> {:ok, value}
+      [] -> {:error, header}
+    end
+  end
+
+  defp get_signing_secret(config) do
+    case Juvet.Config.slack(config) do
+      %{signing_secret: signing_secret} -> {:ok, signing_secret}
+      _ -> {:error, :missing_signing_secret}
+    end
+  end
+
+  defp missing_header_message(header),
+    do: "Request missing #{header} header and could not be verified"
+
+  defp validate_timestamp(slack_timestamp) do
+    timestamp = String.to_integer(slack_timestamp)
+    local_timestamp = GregorianDateTime.to_seconds()
+
+    # TODO: 300 is 5 minutes (60 * 5). Make this configurable
+    if abs(local_timestamp - timestamp) < 300,
+      do: {:ok, timestamp},
+      else: {:error, :stale_timestamp}
+  end
+end

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -7,7 +7,7 @@ defmodule Juvet.Plug do
   """
 
   use Plug.Router
-  use Juvet.SlackEndpointRouter, config: Juvet.configuration()
+  use Juvet.SlackRoutes, config: Juvet.configuration()
 
   def init(opts) do
     config = Keyword.get(opts, :configuration, Juvet.configuration())

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -15,7 +15,7 @@ defmodule Juvet.Plug do
     Keyword.merge(opts, configuration: config)
   end
 
-  plug(Plug.Logger)
+  unless Mix.env() == :test, do: plug(Plug.Logger)
   plug(:insert_juvet_options, builder_opts())
   plug(:match)
 

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -9,7 +9,14 @@ defmodule Juvet.Plug do
   use Plug.Router
   use Juvet.SlackEndpointRouter, config: Juvet.configuration()
 
+  def init(opts) do
+    config = Keyword.get(opts, :configuration, Juvet.configuration())
+
+    Keyword.merge(opts, configuration: config)
+  end
+
   plug(Plug.Logger)
+  plug(:insert_juvet_options, builder_opts())
   plug(:match)
 
   plug(Plug.Parsers,
@@ -23,4 +30,7 @@ defmodule Juvet.Plug do
   # TODO: Make this response configurable like in Phoenix
   # See use Plug.ErrorHandler
   match(_, do: send_resp(conn, 404, "Oh no! This route is not handled in Juvet"))
+
+  defp insert_juvet_options(conn, opts),
+    do: Juvet.Conn.put_private(conn, %{options: opts})
 end

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -1,4 +1,4 @@
-defmodule Juvet.EndpointRouter do
+defmodule Juvet.Plug do
   @moduledoc """
   Specifies the routing for any incoming messages.
 
@@ -11,9 +11,16 @@ defmodule Juvet.EndpointRouter do
 
   plug(Plug.Logger)
   plug(:match)
-  plug(Plug.Parsers, parsers: [:json], json_decoder: Poison)
+
+  plug(Plug.Parsers,
+    parsers: [:json, :multipart, :urlencoded],
+    body_reader: {Juvet.CacheBodyReader, :read_body, []},
+    json_decoder: Poison
+  )
+
   plug(:dispatch)
 
   # TODO: Make this response configurable like in Phoenix
+  # See use Plug.ErrorHandler
   match(_, do: send_resp(conn, 404, "Oh no! This route is not handled in Juvet"))
 end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -1,5 +1,5 @@
 defmodule Juvet.Router do
-  alias Juvet.Router.Platform
+  alias Juvet.Router.{Platform, Route}
 
   defmacro __using__(_opts) do
     quote do
@@ -27,12 +27,8 @@ defmodule Juvet.Router do
   end
 
   defmacro command(command, options \\ []) do
-    IO.puts("******************")
-    IO.puts("ADDING A COMMAND")
-    IO.inspect(command)
-    IO.puts("******************")
-
     quote do
+      Route.new(:command, unquote(command), unquote(options))
     end
   end
 
@@ -46,8 +42,13 @@ defmodule Juvet.Router do
 
   defp add_platform(platform, block) do
     quote do
-      @juvet_platforms Platform.new(unquote(platform))
-      # @juvet_platforms {unquote(platform), unquote(block)}
+      platform = Platform.new(unquote(platform))
+
+      # TODO
+      route = unquote(block)
+      # Platform.put_route(platform, route)
+
+      @juvet_platforms platform
     end
   end
 end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -55,6 +55,14 @@ defmodule Juvet.Router do
     add_platform(platform, block)
   end
 
+  def exists?(mod) do
+    try do
+      Keyword.has_key?(mod.__info__(:functions), :__platforms__)
+    rescue
+      UndefinedFunctionError -> false
+    end
+  end
+
   def find_route(router, request) do
     RouteFinder.find(platforms(router), request)
   end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -1,5 +1,5 @@
 defmodule Juvet.Router do
-  alias Juvet.Router.{Platform, Route}
+  alias Juvet.Router.{Platform, Route, RouteFinder}
 
   defmodule RouteError do
     @moduledoc """
@@ -55,6 +55,10 @@ defmodule Juvet.Router do
     add_platform(platform, block)
   end
 
+  def find_route(router, request) do
+    RouteFinder.find(platforms(router), request)
+  end
+
   def platforms(router) do
     router.__platforms__()
   end
@@ -74,7 +78,7 @@ defmodule Juvet.Router do
             platform = Keyword.fetch!(route_info, :platform)
 
             raise RouteError,
-              message: "Platform `#{platform.platform}` is not valid.",
+              message: "Platform `#{platform.platform.platform}` is not valid.",
               router: __MODULE__
         end
 

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -1,0 +1,42 @@
+defmodule Juvet.Router do
+  defmacro __using__(_opts) do
+    quote do
+      unquote(prelude())
+    end
+  end
+
+  defp prelude do
+    quote do
+      import unquote(__MODULE__)
+
+      Module.register_attribute(__MODULE__, :juvet_platforms, accumulate: true)
+
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    platforms = env.module |> Module.get_attribute(:juvet_platforms)
+
+    quote do
+      def __platforms__, do: unquote(Macro.escape(platforms))
+    end
+  end
+
+  defmacro platform(platform, do: block) do
+    add_platform(platform, block)
+  end
+
+  def platforms(router) do
+    router.__platforms__()
+  end
+
+  defp add_platform(platform, block) do
+    quote do
+      # TODO: I believe this is running the block right now. Do we want that?
+      # Platform.new(unquote(platform), unquote(block))?
+      @juvet_platforms {unquote(platform), unquote(block)}
+    end
+  end
+end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -44,9 +44,9 @@ defmodule Juvet.Router do
     quote do
       platform = Platform.new(unquote(platform))
 
-      # TODO
       route = unquote(block)
-      # Platform.put_route(platform, route)
+      # TODO: Handle invalid route (raise routing error)
+      {:ok, platform} = Platform.put_route(platform, route)
 
       @juvet_platforms platform
     end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -1,4 +1,6 @@
 defmodule Juvet.Router do
+  alias Juvet.Router.Platform
+
   defmacro __using__(_opts) do
     quote do
       unquote(prelude())
@@ -24,6 +26,16 @@ defmodule Juvet.Router do
     end
   end
 
+  defmacro command(command, options \\ []) do
+    IO.puts("******************")
+    IO.puts("ADDING A COMMAND")
+    IO.inspect(command)
+    IO.puts("******************")
+
+    quote do
+    end
+  end
+
   defmacro platform(platform, do: block) do
     add_platform(platform, block)
   end
@@ -34,9 +46,8 @@ defmodule Juvet.Router do
 
   defp add_platform(platform, block) do
     quote do
-      # TODO: I believe this is running the block right now. Do we want that?
-      # Platform.new(unquote(platform), unquote(block))?
-      @juvet_platforms {unquote(platform), unquote(block)}
+      @juvet_platforms Platform.new(unquote(platform))
+      # @juvet_platforms {unquote(platform), unquote(block)}
     end
   end
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -1,0 +1,7 @@
+defmodule Juvet.Router.Platform do
+  defstruct platform: nil
+
+  def new(platform) do
+    %__MODULE__{platform: platform}
+  end
+end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -1,7 +1,7 @@
 defmodule Juvet.Router.Platform do
-  alias Juvet.Router.PlatformFactory
-
   defstruct platform: nil, routes: []
+
+  alias Juvet.Router.PlatformFactory
 
   def new(platform) do
     %__MODULE__{platform: platform}
@@ -18,7 +18,11 @@ defmodule Juvet.Router.Platform do
     end
   end
 
-  def validate_route(%__MODULE__{platform: platform}, route, options \\ %{}) do
+  def find_route(platform, request) do
+    PlatformFactory.new(platform) |> PlatformFactory.find_route(request)
+  end
+
+  def validate_route(platform, route, options \\ %{}) do
     PlatformFactory.new(platform)
     |> PlatformFactory.validate_route(route, options)
   end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -1,7 +1,10 @@
 defmodule Juvet.Router.Platform do
-  defstruct platform: nil
+  defstruct platform: nil, routes: []
 
   def new(platform) do
     %__MODULE__{platform: platform}
+  end
+
+  def push(platform, route, options) do
   end
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -1,10 +1,14 @@
 defmodule Juvet.Router.Platform do
+  alias Juvet.Router.PlatformFactory
+
   defstruct platform: nil, routes: []
 
   def new(platform) do
     %__MODULE__{platform: platform}
   end
 
-  def push(platform, route, options) do
+  def validate_route(%__MODULE__{platform: platform}, route, options \\ %{}) do
+    PlatformFactory.new(platform)
+    |> PlatformFactory.validate_route(route, options)
   end
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -7,6 +7,17 @@ defmodule Juvet.Router.Platform do
     %__MODULE__{platform: platform}
   end
 
+  def put_route(platform, route, options \\ %{}) do
+    case validate_route(platform, route, options) do
+      {:ok, route} ->
+        routes = platform.routes
+        {:ok, %{platform | routes: routes ++ [route]}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
   def validate_route(%__MODULE__{platform: platform}, route, options \\ %{}) do
     PlatformFactory.new(platform)
     |> PlatformFactory.validate_route(route, options)

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -8,4 +8,8 @@ defmodule Juvet.Router.PlatformFactory do
       _ in ArgumentError -> new(:unknown)
     end
   end
+
+  def validate_route(platform, route, options \\ %{}) do
+    platform.validate_route(route, options)
+  end
 end

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -1,4 +1,6 @@
 defmodule Juvet.Router.PlatformFactory do
+  def new(:unknown), do: Juvet.Router.UnknownPlatform
+
   def new(platform) do
     try do
       String.to_existing_atom(

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -1,5 +1,5 @@
 defmodule Juvet.Router.PlatformFactory do
-  def new(:unknown), do: Juvet.Router.UnknownPlatform
+  def new(:unknown, platform), do: Juvet.Router.UnknownPlatform.new(platform)
 
   def new(platform) do
     try do
@@ -7,11 +7,17 @@ defmodule Juvet.Router.PlatformFactory do
         "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform"
       )
     rescue
-      _ in ArgumentError -> new(:unknown)
+      _ in ArgumentError -> new(:unknown, platform)
     end
   end
 
-  def validate_route(platform, route, options \\ %{}) do
-    platform.validate_route(route, options)
+  def validate_route(platform, route, options \\ %{})
+
+  def validate_route(%{__struct__: struct} = platform, route, options) do
+    platform |> struct.validate_route(route, options)
+  end
+
+  def validate_route(platform, route, options) do
+    platform |> platform.validate_route(route, options)
   end
 end

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -3,12 +3,25 @@ defmodule Juvet.Router.PlatformFactory do
 
   def new(platform) do
     try do
-      String.to_existing_atom(
-        "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform"
-      )
+      mod =
+        String.to_existing_atom(
+          "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform.platform))}Platform"
+        )
+
+      apply(mod, :new, [platform])
     rescue
       _ in ArgumentError -> new(:unknown, platform)
     end
+  end
+
+  def find_route(platform, request)
+
+  def find_route(%{__struct__: struct} = platform, request) do
+    platform |> struct.find_route(request)
+  end
+
+  def find_route(platform, request) do
+    platform |> platform.find_route(request)
   end
 
   def validate_route(platform, route, options \\ %{})

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -1,0 +1,11 @@
+defmodule Juvet.Router.PlatformFactory do
+  def new(platform) do
+    try do
+      String.to_existing_atom(
+        "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform"
+      )
+    rescue
+      _ in ArgumentError -> new(:unknown)
+    end
+  end
+end

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -10,6 +10,7 @@ defmodule Juvet.Router.Request do
     :scheme,
     :status,
     headers: [],
+    platform: :unknown,
     verified?: false
   ]
 

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -15,16 +15,16 @@ defmodule Juvet.Router.Request do
 
   def new(conn) do
     %__MODULE__{
-      headers: conn.req_headers,
-      host: conn.host,
-      method: conn.method,
-      params: conn.params,
-      path: conn.request_path,
-      port: conn.port,
-      private: conn.private,
-      query_string: conn.query_string,
-      scheme: conn.scheme,
-      status: conn.status
+      headers: Map.get(conn, :req_headers),
+      host: Map.get(conn, :host),
+      method: Map.get(conn, :method),
+      params: Map.get(conn, :params),
+      path: Map.get(conn, :request_path),
+      port: Map.get(conn, :port),
+      private: Map.get(conn, :private),
+      query_string: Map.get(conn, :query_string),
+      scheme: Map.get(conn, :scheme),
+      status: Map.get(conn, :status)
     }
   end
 

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -1,4 +1,4 @@
-defmodule Juvet.Middleware.Request do
+defmodule Juvet.Router.Request do
   defstruct headers: [],
             host: nil,
             method: nil,

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -29,6 +29,8 @@ defmodule Juvet.Router.Request do
     }
   end
 
+  def get_header(%__MODULE__{headers: nil}, _header), do: []
+
   def get_header(%__MODULE__{headers: headers}, header) do
     for {^header, value} <- headers, do: value
   end

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -9,7 +9,8 @@ defmodule Juvet.Router.Request do
     :query_string,
     :scheme,
     :status,
-    headers: []
+    headers: [],
+    verified?: false
   ]
 
   def new(conn) do

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -22,4 +22,8 @@ defmodule Juvet.Router.Request do
       status: conn.status
     }
   end
+
+  def get_header(%__MODULE__{headers: headers}, header) do
+    for {^header, value} <- headers, do: value
+  end
 end

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -1,13 +1,16 @@
 defmodule Juvet.Router.Request do
-  defstruct headers: [],
-            host: nil,
-            method: nil,
-            params: nil,
-            path: nil,
-            port: nil,
-            query_string: nil,
-            scheme: nil,
-            status: nil
+  defstruct [
+    :host,
+    :method,
+    :params,
+    :path,
+    :port,
+    :private,
+    :query_string,
+    :scheme,
+    :status,
+    headers: []
+  ]
 
   def new(conn) do
     %__MODULE__{
@@ -17,6 +20,7 @@ defmodule Juvet.Router.Request do
       params: conn.params,
       path: conn.request_path,
       port: conn.port,
+      private: conn.private,
       query_string: conn.query_string,
       scheme: conn.scheme,
       status: conn.status

--- a/lib/juvet/router/route.ex
+++ b/lib/juvet/router/route.ex
@@ -4,4 +4,8 @@ defmodule Juvet.Router.Route do
   def new(type, route, options \\ []) do
     %__MODULE__{type: type, route: route, options: options}
   end
+
+  def path(%{options: options}) do
+    Keyword.get(options, :to)
+  end
 end

--- a/lib/juvet/router/route.ex
+++ b/lib/juvet/router/route.ex
@@ -1,0 +1,7 @@
+defmodule Juvet.Router.Route do
+  defstruct type: nil, route: nil, options: []
+
+  def new(type, route, options \\ []) do
+    %__MODULE__{type: type, route: route, options: options}
+  end
+end

--- a/lib/juvet/router/route_finder.ex
+++ b/lib/juvet/router/route_finder.ex
@@ -1,0 +1,23 @@
+defmodule Juvet.Router.RouteFinder do
+  alias Juvet.Router.Platform
+
+  def find(platforms, request) do
+    route =
+      Enum.map(platforms, fn platform ->
+        case find_route(platform, request) do
+          {:error, _error} -> nil
+          {:ok, route} -> route
+        end
+      end)
+      |> List.first()
+
+    case route do
+      nil -> {:error, :not_found}
+      route -> {:ok, route}
+    end
+  end
+
+  def find_route(platform, request) do
+    Platform.find_route(platform, request)
+  end
+end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -1,12 +1,11 @@
 defmodule Juvet.Router.SlackPlatform do
-  def validate_route(route, options \\ %{})
-
   def validate_route(
+        _platform,
         %Juvet.Router.Route{type: :command} = route,
         _options
       ),
       do: {:ok, route}
 
-  def validate_route(%Juvet.Router.Route{} = route, options),
-    do: {:error, {:routing_error, [route: route, options: options]}}
+  def validate_route(_platform, %Juvet.Router.Route{} = route, options),
+    do: {:error, {:unknown_route, [route: route, options: options]}}
 end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -46,6 +46,6 @@ defmodule Juvet.Router.SlackPlatform do
   defp normalized_command(nil), do: nil
 
   defp normalized_command(command) do
-    command |> String.trim() |> String.downcase()
+    command |> String.trim() |> String.downcase() |> command_without_slash()
   end
 end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -1,4 +1,30 @@
 defmodule Juvet.Router.SlackPlatform do
+  defstruct platform: nil
+
+  def new(platform) do
+    %__MODULE__{platform: platform}
+  end
+
+  def find_route(platform, %{verified?: false} = request),
+    do: {:error, {:unverified_route, [platform: platform, request: request]}}
+
+  def find_route(
+        %{platform: %{routes: routes}} = platform,
+        %{platform: :slack, verified?: true} = request
+      ) do
+    case Enum.find(routes, &(!is_nil(find_route(&1, request)))) do
+      nil -> {:error, {:unknown_route, [platform: platform, request: request]}}
+      route -> {:ok, route}
+    end
+  end
+
+  def find_route(
+        %Juvet.Router.Route{type: :command, route: command_text} = route,
+        request
+      ) do
+    if command_request?(request, command_without_slash(command_text)), do: route
+  end
+
   def validate_route(
         _platform,
         %Juvet.Router.Route{type: :command} = route,
@@ -6,6 +32,20 @@ defmodule Juvet.Router.SlackPlatform do
       ),
       do: {:ok, route}
 
-  def validate_route(_platform, %Juvet.Router.Route{} = route, options),
-    do: {:error, {:unknown_route, [route: route, options: options]}}
+  def validate_route(platform, %Juvet.Router.Route{} = route, options),
+    do:
+      {:error,
+       {:unknown_route, [platform: platform, route: route, options: options]}}
+
+  defp command_request?(%{params: params}, command) do
+    normalized_command(params["command"]) == normalized_command(command)
+  end
+
+  defp command_without_slash(command), do: String.trim_leading(command, "/")
+
+  defp normalized_command(nil), do: nil
+
+  defp normalized_command(command) do
+    command |> String.trim() |> String.downcase()
+  end
 end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -1,0 +1,12 @@
+defmodule Juvet.Router.SlackPlatform do
+  def validate_route(route, options \\ %{})
+
+  def validate_route(
+        %Juvet.Router.Route{type: :command} = route,
+        _options
+      ),
+      do: {:ok, route}
+
+  def validate_route(%Juvet.Router.Route{} = route, options),
+    do: {:error, {:routing_error, [route: route, options: options]}}
+end

--- a/lib/juvet/router/unknown_platform.ex
+++ b/lib/juvet/router/unknown_platform.ex
@@ -1,0 +1,4 @@
+defmodule Juvet.Router.UnknownPlatform do
+  def validate_route(route, options \\ %{}),
+    do: {:error, {:routing_error, [route: route, options: options]}}
+end

--- a/lib/juvet/router/unknown_platform.ex
+++ b/lib/juvet/router/unknown_platform.ex
@@ -1,4 +1,12 @@
 defmodule Juvet.Router.UnknownPlatform do
-  def validate_route(route, options \\ %{}),
-    do: {:error, {:routing_error, [route: route, options: options]}}
+  defstruct platform: nil
+
+  def new(platform) do
+    %__MODULE__{platform: platform}
+  end
+
+  def validate_route(platform, route, options \\ %{}) do
+    {:error,
+     {:unknown_platform, [platform: platform, route: route, options: options]}}
+  end
 end

--- a/lib/juvet/routing_error.ex
+++ b/lib/juvet/routing_error.ex
@@ -1,0 +1,10 @@
+defmodule Juvet.RoutingError do
+  @moduledoc """
+  Exception raised when there is an issue with routing a request.
+  """
+  defexception message: "Invalid route", request: nil
+
+  def exception(message, request) do
+    %__MODULE__{message: message, request: request}
+  end
+end

--- a/lib/juvet/runner.ex
+++ b/lib/juvet/runner.ex
@@ -2,10 +2,28 @@ defmodule Juvet.Runner do
   alias Juvet.{Middleware, MiddlewareProcessor}
 
   def route(path, context \\ %{}) do
-    %{configuration: Juvet.configuration()}
+    {configuration, context} = Map.pop(context, :configuration)
+
+    default_configuration(configuration)
     |> Map.merge(%{path: path})
     |> Map.merge(context)
     |> Map.merge(%{middleware: Middleware.group(:partial)})
     |> MiddlewareProcessor.process()
+  end
+
+  def run(conn, context \\ %{}) do
+    {configuration, context} = Map.pop(context, :configuration)
+
+    default_configuration(configuration)
+    |> Map.merge(%{conn: conn})
+    |> Map.merge(context)
+    |> Map.merge(%{middleware: Middleware.group(:all)})
+    |> MiddlewareProcessor.process()
+  end
+
+  defp default_configuration(nil), do: %{configuration: Juvet.configuration()}
+
+  defp default_configuration(configuration) do
+    %{configuration: Keyword.merge(Juvet.configuration(), configuration)}
   end
 end

--- a/lib/juvet/slack_action_route.ex
+++ b/lib/juvet/slack_action_route.ex
@@ -1,6 +1,6 @@
-defmodule Juvet.SlackActionsEndpointRouter do
+defmodule Juvet.SlackActionRoute do
   @moduledoc """
-  Endpoint router to handle all messages for Slack actions.
+  Plug to handle any action from Slack.
   """
 
   import Plug.Conn

--- a/lib/juvet/slack_actions_endpoint_router.ex
+++ b/lib/juvet/slack_actions_endpoint_router.ex
@@ -11,7 +11,7 @@ defmodule Juvet.SlackActionsEndpointRouter do
   @doc """
   Handles web requests targeted for the Slack actions API endpoint.
   """
-  def call(conn, _config) do
+  def call(conn, _opts) do
     send_resp(conn, 200, "")
   end
 end

--- a/lib/juvet/slack_command_route.ex
+++ b/lib/juvet/slack_command_route.ex
@@ -13,8 +13,9 @@ defmodule Juvet.SlackCommandRoute do
   """
   def call(conn, _opts) do
     config = get_config(conn)
+    context = get_context(conn)
 
-    case Juvet.Runner.run(conn, %{configuration: config}) do
+    case Juvet.Runner.run(conn, Map.merge(%{configuration: config}, context)) do
       {:ok, _context} ->
         send_resp(conn, 200, "")
         |> halt()
@@ -27,10 +28,20 @@ defmodule Juvet.SlackCommandRoute do
   defp get_config(%Plug.Conn{} = conn),
     do: get_config(Juvet.Conn.get_private(conn))
 
-  defp get_config(%{options: [configuration: configuration]}),
-    do: configuration
+  defp get_config(%{options: options}) do
+    get_in(options, [:configuration]) || []
+  end
 
   defp get_config(_), do: []
+
+  defp get_context(%Plug.Conn{} = conn),
+    do: get_context(Juvet.Conn.get_private(conn))
+
+  defp get_context(%{options: options}) do
+    get_in(options, [:context]) || %{}
+  end
+
+  defp get_context(_), do: %{}
 
   # TODO: Do something clever here
   defp send_error(conn, _error), do: conn |> send_resp(200, "")

--- a/lib/juvet/slack_command_route.ex
+++ b/lib/juvet/slack_command_route.ex
@@ -1,6 +1,6 @@
-defmodule Juvet.SlackCommandsEndpointRouter do
+defmodule Juvet.SlackCommandRoute do
   @moduledoc """
-  Endpoint router to handle all messages for Slack commands.
+  Plug to handle any command from Slack.
   """
 
   import Plug.Conn

--- a/lib/juvet/slack_commands_endpoint_router.ex
+++ b/lib/juvet/slack_commands_endpoint_router.ex
@@ -11,7 +11,9 @@ defmodule Juvet.SlackCommandsEndpointRouter do
   @doc """
   Handles web requests targeted for the Slack commands API endpoint.
   """
-  def call(conn, config) do
+  def call(conn, _opts) do
+    config = get_config(conn)
+
     case Juvet.Runner.run(conn, %{configuration: config}) do
       {:ok, _context} ->
         send_resp(conn, 200, "")
@@ -21,6 +23,14 @@ defmodule Juvet.SlackCommandsEndpointRouter do
         send_error(conn, error)
     end
   end
+
+  defp get_config(%Plug.Conn{} = conn),
+    do: get_config(Juvet.Conn.get_private(conn))
+
+  defp get_config(%{options: [configuration: configuration]}),
+    do: configuration
+
+  defp get_config(_), do: []
 
   # TODO: Do something clever here
   defp send_error(conn, _error), do: conn |> send_resp(200, "")

--- a/lib/juvet/slack_commands_endpoint_router.ex
+++ b/lib/juvet/slack_commands_endpoint_router.ex
@@ -1,0 +1,27 @@
+defmodule Juvet.SlackCommandsEndpointRouter do
+  @moduledoc """
+  Endpoint router to handle all messages for Slack commands.
+  """
+
+  import Plug.Conn
+
+  @doc false
+  def init(opts), do: opts
+
+  @doc """
+  Handles web requests targeted for the Slack commands API endpoint.
+  """
+  def call(conn, config) do
+    case Juvet.Runner.run(conn, %{configuration: config}) do
+      {:ok, _context} ->
+        send_resp(conn, 200, "")
+        |> halt()
+
+      {:error, error} ->
+        send_error(conn, error)
+    end
+  end
+
+  # TODO: Do something clever here
+  defp send_error(conn, _error), do: conn |> send_resp(200, "")
+end

--- a/lib/juvet/slack_endpoint_router.ex
+++ b/lib/juvet/slack_endpoint_router.ex
@@ -1,3 +1,4 @@
+# TODO: Rename to Juvet.SlackRoutes? Rename plus below
 defmodule Juvet.SlackEndpointRouter do
   @moduledoc """
   Creates routes necessary for incoming Slack messages from configuration.
@@ -5,10 +6,6 @@ defmodule Juvet.SlackEndpointRouter do
 
   defmacro __using__(opts) do
     config = Keyword.get(opts, :config)
-
-    # TODO: This is garbage. Would rather allow for any module to be
-    # defined and act as an endpoint router for the endpoint. Not
-    # quite sure how to do that yet,
 
     quote bind_quoted: [config: config] do
       if Juvet.Config.slack_configured?(config) do
@@ -34,7 +31,7 @@ defmodule Juvet.SlackEndpointRouter do
         if commands_endpoint,
           do:
             post(commands_endpoint,
-              to: Juvet.SlackActionsEndpointRouter,
+              to: Juvet.SlackCommandsEndpointRouter,
               init_opts: config
             )
 

--- a/lib/juvet/slack_endpoint_router.ex
+++ b/lib/juvet/slack_endpoint_router.ex
@@ -12,15 +12,29 @@ defmodule Juvet.SlackEndpointRouter do
 
     quote bind_quoted: [config: config] do
       if Juvet.Config.slack_configured?(config) do
-        defaults = %{actions_endpoint: nil, events_endpoint: nil}
+        defaults = %{
+          actions_endpoint: nil,
+          commands_endpoint: nil,
+          events_endpoint: nil
+        }
 
-        %{actions_endpoint: actions_endpoint, events_endpoint: events_endpoint} =
-          Map.merge(defaults, Juvet.Config.slack(config))
+        %{
+          actions_endpoint: actions_endpoint,
+          commands_endpoint: commands_endpoint,
+          events_endpoint: events_endpoint
+        } = Map.merge(defaults, Juvet.Config.slack(config))
 
         if events_endpoint,
           do:
             post(events_endpoint,
               to: Juvet.SlackEventsEndpointRouter,
+              init_opts: config
+            )
+
+        if commands_endpoint,
+          do:
+            post(commands_endpoint,
+              to: Juvet.SlackActionsEndpointRouter,
               init_opts: config
             )
 

--- a/lib/juvet/slack_endpoint_router.ex
+++ b/lib/juvet/slack_endpoint_router.ex
@@ -24,22 +24,19 @@ defmodule Juvet.SlackEndpointRouter do
         if events_endpoint,
           do:
             post(events_endpoint,
-              to: Juvet.SlackEventsEndpointRouter,
-              init_opts: config
+              to: Juvet.SlackEventsEndpointRouter
             )
 
         if commands_endpoint,
           do:
             post(commands_endpoint,
-              to: Juvet.SlackCommandsEndpointRouter,
-              init_opts: config
+              to: Juvet.SlackCommandsEndpointRouter
             )
 
         if actions_endpoint,
           do:
             post(actions_endpoint,
-              to: Juvet.SlackActionsEndpointRouter,
-              init_opts: config
+              to: Juvet.SlackActionsEndpointRouter
             )
       end
     end

--- a/lib/juvet/slack_events_endpoint_router.ex
+++ b/lib/juvet/slack_events_endpoint_router.ex
@@ -11,7 +11,7 @@ defmodule Juvet.SlackEventsEndpointRouter do
   @doc """
   Handles web requests targeted for the Slack events API endpoint.
   """
-  def call(conn, _config) do
+  def call(conn, _opts) do
     send_resp(conn, 200, "")
   end
 end

--- a/lib/juvet/slack_events_endpoint_router.ex
+++ b/lib/juvet/slack_events_endpoint_router.ex
@@ -1,6 +1,6 @@
-defmodule Juvet.SlackEventsEndpointRouter do
+defmodule Juvet.SlackEventRoute do
   @moduledoc """
-  Endpoint router to handle all messages for Slack events.
+  Plug to handle any event from Slack.
   """
 
   import Plug.Conn

--- a/lib/juvet/slack_routes.ex
+++ b/lib/juvet/slack_routes.ex
@@ -21,22 +21,13 @@ defmodule Juvet.SlackRoutes do
         } = Map.merge(defaults, Juvet.Config.slack(config))
 
         if events_endpoint,
-          do:
-            post(events_endpoint,
-              to: Juvet.SlackEventsEndpointRouter
-            )
+          do: post(events_endpoint, to: Juvet.SlackEventRoute)
 
         if commands_endpoint,
-          do:
-            post(commands_endpoint,
-              to: Juvet.SlackCommandsEndpointRouter
-            )
+          do: post(commands_endpoint, to: Juvet.SlackCommandRoute)
 
         if actions_endpoint,
-          do:
-            post(actions_endpoint,
-              to: Juvet.SlackActionsEndpointRouter
-            )
+          do: post(actions_endpoint, to: Juvet.SlackActionRoute)
       end
     end
   end

--- a/lib/juvet/slack_routes.ex
+++ b/lib/juvet/slack_routes.ex
@@ -1,5 +1,4 @@
-# TODO: Rename to Juvet.SlackRoutes? Rename plus below
-defmodule Juvet.SlackEndpointRouter do
+defmodule Juvet.SlackRoutes do
   @moduledoc """
   Creates routes necessary for incoming Slack messages from configuration.
   """

--- a/lib/juvet/slack_signing_secret.ex
+++ b/lib/juvet/slack_signing_secret.ex
@@ -1,0 +1,24 @@
+defmodule Juvet.SlackSigningSecret do
+  def generate(body, signing_secret, timestamp \\ NaiveDateTime.utc_now())
+
+  def generate(body, signing_secret, timestamp) when is_integer(timestamp),
+    do: generate(body, signing_secret, to_string(timestamp))
+
+  def generate(body, signing_secret, timestamp) when is_binary(timestamp) do
+    "v0=#{
+      :crypto.mac(
+        :hmac,
+        :sha256,
+        signing_secret,
+        "v0:#{timestamp}:#{body}"
+      )
+      |> Base.encode16()
+    }"
+    |> String.downcase()
+  end
+
+  def generate(body, signing_secret, timestamp) do
+    timestamp = Juvet.GregorianDateTime.to_seconds(timestamp) |> to_string
+    generate(body, signing_secret, timestamp)
+  end
+end

--- a/test/juvet/cache_body_reader_test.exs
+++ b/test/juvet/cache_body_reader_test.exs
@@ -1,0 +1,29 @@
+defmodule Juvet.CacheBodyReaderTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+
+  alias Juvet.CacheBodyReader
+
+  describe "read_body/2" do
+    setup do
+      [conn: request!(:post, "/blah")]
+    end
+
+    test "puts the raw body into the juvet shared library", %{conn: conn} do
+      {:ok, _body, conn} = CacheBodyReader.read_body(conn, [])
+
+      assert conn.private[:juvet][:raw_body]
+    end
+
+    test "merges with any existing entries in the juvet shared library", %{
+      conn: conn
+    } do
+      conn = conn |> Plug.Conn.put_private(:juvet, %{blah: "blah"})
+
+      {:ok, _body, conn} = CacheBodyReader.read_body(conn, [])
+
+      assert conn.private[:juvet][:blah] == "blah"
+      assert conn.private[:juvet][:raw_body]
+    end
+  end
+end

--- a/test/juvet/conn_test.exs
+++ b/test/juvet/conn_test.exs
@@ -1,0 +1,25 @@
+defmodule Juvet.ConnTest do
+  use ExUnit.Case, async: true
+
+  describe "put_private/2" do
+    setup do
+      conn = %Plug.Conn{}
+
+      [conn: conn]
+    end
+
+    test "adds value to the private juvet key in the conn", %{conn: conn} do
+      conn = Juvet.Conn.put_private(conn, %{foo: :bar})
+
+      assert conn.private[:juvet] == %{foo: :bar}
+    end
+
+    test "merges existing private juvet values", %{conn: conn} do
+      conn = Plug.Conn.put_private(conn, :juvet, %{blah: "blah"})
+
+      conn = Juvet.Conn.put_private(conn, %{foo: :bar})
+
+      assert conn.private[:juvet] == %{blah: "blah", foo: :bar}
+    end
+  end
+end

--- a/test/juvet/endpoint_router_test.exs
+++ b/test/juvet/endpoint_router_test.exs
@@ -1,6 +1,14 @@
 defmodule Juvet.EndpointTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  use Juvet.PlugHelpers
+
+  describe "POST /slack/commands" do
+    test "responds with a 200 status" do
+      conn = request!(:post, "/slack/commands")
+
+      assert conn.status == 200
+    end
+  end
 
   describe "POST /slack/events" do
     test "responds with a 200 status" do
@@ -16,10 +24,5 @@ defmodule Juvet.EndpointTest do
 
       assert conn.status == 404
     end
-  end
-
-  defp request!(method, path) do
-    conn(method, path)
-    |> Juvet.EndpointRouter.call(Juvet.EndpointRouter.init([]))
   end
 end

--- a/test/juvet/gregorian_date_time_test.exs
+++ b/test/juvet/gregorian_date_time_test.exs
@@ -1,0 +1,13 @@
+defmodule Juvet.GregorianDateTimeTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.GregorianDateTime
+
+  describe "to_seconds/1" do
+    test "returns the provided timestamp to Gregorian seconds" do
+      {:ok, date_time} = NaiveDateTime.new(~D[2021-04-04], ~T[23:04:07])
+
+      assert 1_617_577_447 = GregorianDateTime.to_seconds(date_time)
+    end
+  end
+end

--- a/test/juvet/integration/slack_command_test.exs
+++ b/test/juvet/integration/slack_command_test.exs
@@ -1,0 +1,62 @@
+defmodule Juvet.Integration.SlackCommandTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      command("/test", to: "juvet.integration.slack_command_test.test#action")
+    end
+  end
+
+  defmodule TestController do
+    def action(%{pid: pid}) do
+      send(pid, :called_controller)
+    end
+  end
+
+  def fixture(:valid_slack_command) do
+    [
+      {"token", "SLACK_TOKEN"},
+      {"team_id", "T1234"},
+      {"command", "test"},
+      {"text", ""}
+    ]
+    |> Enum.into(%{})
+  end
+
+  def routed_to(_conn, _route), do: false
+
+  describe "with a valid Slack command" do
+    setup do
+      signing_secret = generate_slack_signing_secret()
+
+      [signing_secret: signing_secret]
+    end
+
+    test "is routed correctly", %{signing_secret: signing_secret} do
+      params = fixture(:valid_slack_command)
+
+      conn =
+        request!(
+          :post,
+          "/slack/commands",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      # Request was successful and will not continue in the request chain
+      assert conn.halted
+
+      assert_received :called_controller
+    end
+  end
+end

--- a/test/juvet/integration/slack_command_test.exs
+++ b/test/juvet/integration/slack_command_test.exs
@@ -21,7 +21,7 @@ defmodule Juvet.Integration.SlackCommandTest do
     [
       {"token", "SLACK_TOKEN"},
       {"team_id", "T1234"},
-      {"command", "test"},
+      {"command", "/test"},
       {"text", ""}
     ]
     |> Enum.into(%{})

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.Middleware.ActionGeneratorTest do
   use ExUnit.Case, async: true
 
-  describe "Juvet.Middleware.ActionGenerator.call/1" do
+  describe "call/1" do
     setup do
       [context: %{path: "test#action"}]
     end

--- a/test/juvet/middleware/identify_request_test.exs
+++ b/test/juvet/middleware/identify_request_test.exs
@@ -1,0 +1,44 @@
+defmodule Juvet.Middleware.IdentifyRequestTest do
+  use ExUnit.Case, async: true
+
+  describe "call/1" do
+    test "identifies slack requests" do
+      request =
+        Juvet.Router.Request.new(%{
+          req_headers: [{"x-slack-signature", "blah"}]
+        })
+
+      assert {:ok, ctx} =
+               Juvet.Middleware.IdentifyRequest.call(%{request: request})
+
+      assert ctx[:request].platform == :slack
+    end
+
+    test "returns unknown if there is no request" do
+      assert {:ok, ctx} = Juvet.Middleware.IdentifyRequest.call(%{})
+
+      assert ctx == %{}
+    end
+
+    test "returns unknown if there are no headers in the request" do
+      request = Juvet.Router.Request.new(%{})
+
+      assert {:ok, ctx} =
+               Juvet.Middleware.IdentifyRequest.call(%{request: request})
+
+      assert ctx[:request].platform == :unknown
+    end
+
+    test "returns unknown if the headers were not identified" do
+      request =
+        Juvet.Router.Request.new(%{
+          req_headers: [{"blah", "blah"}]
+        })
+
+      assert {:ok, ctx} =
+               Juvet.Middleware.IdentifyRequest.call(%{request: request})
+
+      assert ctx[:request].platform == :unknown
+    end
+  end
+end

--- a/test/juvet/middleware/identify_request_test.exs
+++ b/test/juvet/middleware/identify_request_test.exs
@@ -14,6 +14,19 @@ defmodule Juvet.Middleware.IdentifyRequestTest do
       assert ctx[:request].platform == :slack
     end
 
+    test "identifies slack request no matter where the header is" do
+      request =
+        Juvet.Router.Request.new(%{
+          req_headers: [
+            {"x-something-else", "bleh"},
+            {"x-slack-signature", "blah"}
+          ]
+        })
+
+      assert {:ok, %{request: %{platform: :slack}}} =
+               Juvet.Middleware.IdentifyRequest.call(%{request: request})
+    end
+
     test "returns unknown if there is no request" do
       assert {:ok, ctx} = Juvet.Middleware.IdentifyRequest.call(%{})
 

--- a/test/juvet/middleware/parse_request_test.exs
+++ b/test/juvet/middleware/parse_request_test.exs
@@ -1,0 +1,17 @@
+defmodule Juvet.Middleware.ParseRequestTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+
+  describe "call/1" do
+    setup do
+      conn = request!(:post, "/slack/commands")
+
+      [context: %{conn: conn}]
+    end
+
+    test "returns a request from the conn", %{context: context} do
+      assert {:ok, ctx} = Juvet.Middleware.ParseRequest.call(context)
+      assert ctx[:request].status == 200
+    end
+  end
+end

--- a/test/juvet/middleware/parse_request_test.exs
+++ b/test/juvet/middleware/parse_request_test.exs
@@ -1,10 +1,14 @@
 defmodule Juvet.Middleware.ParseRequestTest do
   use ExUnit.Case, async: true
-  use Juvet.PlugHelpers
 
   describe "call/1" do
     setup do
-      conn = request!(:post, "/slack/commands")
+      conn = %Plug.Conn{
+        method: "POST",
+        params: %{foo: :bar},
+        request_path: "/slack/commands",
+        status: 200
+      }
 
       [context: %{conn: conn}]
     end

--- a/test/juvet/middleware/request_test.exs
+++ b/test/juvet/middleware/request_test.exs
@@ -1,0 +1,29 @@
+defmodule Juvet.Middleware.RequestTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+
+  describe "new/1" do
+    setup do
+      conn = request!(:post, "/slack/commands", %{foo: :bar})
+
+      [conn: conn]
+    end
+
+    test "returns a structure from the conn", %{conn: conn} do
+      request = Juvet.Middleware.Request.new(conn)
+
+      assert request.headers == [
+               {"content-type", "multipart/mixed; boundary=plug_conn_test"}
+             ]
+
+      assert request.host == "www.example.com"
+      assert request.method == "POST"
+      assert request.params == %{"foo" => :bar}
+      assert request.path == "/slack/commands"
+      assert request.port == 80
+      assert request.query_string == ""
+      assert request.scheme == :http
+      assert request.status == 200
+    end
+  end
+end

--- a/test/juvet/middleware/route_request_test.exs
+++ b/test/juvet/middleware/route_request_test.exs
@@ -1,0 +1,70 @@
+defmodule Juvet.Middleware.RouteRequestTest do
+  use ExUnit.Case, async: true
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      command("/test", to: "controller#action")
+    end
+  end
+
+  describe "call/1" do
+    setup do
+      configuration = [router: MyRouter]
+      params = %{"command" => "test"}
+      request = Juvet.Router.Request.new(%{params: params})
+      request = %{request | verified?: true, platform: :slack}
+
+      [context: %{configuration: configuration, request: request}]
+    end
+
+    test "adds a route and a path to the context if the route was found", %{
+      context: context
+    } do
+      assert {:ok, ctx} = Juvet.Middleware.RouteRequest.call(context)
+
+      assert ctx[:route] == %Juvet.Router.Route{
+               route: "/test",
+               type: :command,
+               options: [to: "controller#action"]
+             }
+
+      assert ctx[:path] == "controller#action"
+    end
+
+    test "returns an error if the route was not found", %{
+      context: %{request: request} = context
+    } do
+      request = %{request | params: %{"command" => "blah"}}
+      context = %{context | request: request}
+
+      assert {:error,
+              %Juvet.RoutingError{
+                message: "No route found for the request.",
+                request: request
+              }} = Juvet.Middleware.RouteRequest.call(context)
+    end
+
+    test "returns an error if router is not configured", %{context: context} do
+      configuration = []
+      context = %{context | configuration: configuration}
+
+      assert {:error,
+              %Juvet.ConfigurationError{
+                message: "Router missing in Juvet configuration."
+              }} = Juvet.Middleware.RouteRequest.call(context)
+    end
+
+    test "returns an error if router could not be found", %{context: context} do
+      configuration = [router: Blah]
+      context = %{context | configuration: configuration}
+
+      assert {:error,
+              %Juvet.ConfigurationError{
+                message:
+                  "Router Blah configured in Juvet configuration is not found."
+              }} = Juvet.Middleware.RouteRequest.call(context)
+    end
+  end
+end

--- a/test/juvet/middleware/route_request_test.exs
+++ b/test/juvet/middleware/route_request_test.exs
@@ -12,7 +12,7 @@ defmodule Juvet.Middleware.RouteRequestTest do
   describe "call/1" do
     setup do
       configuration = [router: MyRouter]
-      params = %{"command" => "test"}
+      params = %{"command" => "/test"}
       request = Juvet.Router.Request.new(%{params: params})
       request = %{request | verified?: true, platform: :slack}
 
@@ -36,7 +36,7 @@ defmodule Juvet.Middleware.RouteRequestTest do
     test "returns an error if the route was not found", %{
       context: %{request: request} = context
     } do
-      request = %{request | params: %{"command" => "blah"}}
+      request = %{request | params: %{"command" => "/blah"}}
       context = %{context | request: request}
 
       assert {:error,

--- a/test/juvet/middleware/route_request_test.exs
+++ b/test/juvet/middleware/route_request_test.exs
@@ -66,5 +66,15 @@ defmodule Juvet.Middleware.RouteRequestTest do
                   "Router Blah configured in Juvet configuration is not found."
               }} = Juvet.Middleware.RouteRequest.call(context)
     end
+
+    test "returns an error if the request was not verified", %{
+      context: %{request: request} = context
+    } do
+      request = %{request | verified?: false}
+      context = %{context | request: request}
+
+      assert {:error, %Juvet.RoutingError{message: "Request was not verified."}} =
+               Juvet.Middleware.RouteRequest.call(context)
+    end
   end
 end

--- a/test/juvet/middleware/slack/verify_request_test.exs
+++ b/test/juvet/middleware/slack/verify_request_test.exs
@@ -1,0 +1,143 @@
+defmodule Juvet.Middleware.Slack.VerifyRequestTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+
+  describe "call/1" do
+    setup do
+      params = %{"token" => "TOKEN", "team_id" => "T12345"}
+      body = params |> URI.encode_query()
+
+      signing_secret = "646ed265b0d3bec1cf8e6bb03dbf5086"
+      config = [slack: [signing_secret: signing_secret]]
+      timestamp = Juvet.GregorianDateTime.to_seconds() |> to_string
+      signature = "v0:#{timestamp}:#{body}"
+
+      signature =
+        "v0=#{
+          :crypto.mac(:hmac, :sha256, signing_secret, signature)
+          |> Base.encode16()
+        }"
+        |> String.downcase()
+
+      request =
+        Juvet.Router.Request.new(%{
+          private: %{juvet: %{raw_body: body}},
+          req_headers: [
+            {"x-slack-request-timestamp", timestamp},
+            {"x-slack-signature", signature}
+          ]
+        })
+
+      [
+        context: %{
+          configuration: config,
+          request: %{request | platform: :slack}
+        },
+        signature: signature,
+        timestamp: timestamp
+      ]
+    end
+
+    test "returns the context for a valid request", %{context: context} do
+      assert {:ok, ctx} = Juvet.Middleware.Slack.VerifyRequest.call(context)
+      assert ctx[:request].verified?
+    end
+
+    test "returns an error if the Slack timestamp header is not available", %{
+      context: %{request: request} = context,
+      signature: signature
+    } do
+      request = %{request | headers: [{"x-slack-signature", signature}]}
+
+      message =
+        "Request missing x-slack-request-timestamp header and could not be verified"
+
+      assert {:error, %Juvet.InvalidRequestError{message: ^message}} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | request: request
+               })
+    end
+
+    test "returns an error if there is no raw body set", %{
+      context: %{request: request} = context
+    } do
+      request = %{request | private: nil}
+
+      assert {:error,
+              %Juvet.InvalidRequestError{
+                message:
+                  "Request body was empty and could not be verified. Ensure you are caching the request body in a body reader plug."
+              }} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | request: request
+               })
+    end
+
+    test "returns an error if the timestamp is older than five minutes", %{
+      context: %{request: request} = context,
+      signature: signature
+    } do
+      timestamp =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-6 * 60)
+        |> Juvet.GregorianDateTime.to_seconds()
+        |> to_string
+
+      request = %{
+        request
+        | headers: [
+            {"x-slack-request-timestamp", timestamp},
+            {"x-slack-signature", signature}
+          ]
+      }
+
+      assert {:error,
+              %Juvet.InvalidRequestError{
+                message: "Stale Slack request."
+              }} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | request: request
+               })
+    end
+
+    test "returns an error if the signing signature is not configured", %{
+      context: %{configuration: configuration} = context
+    } do
+      config = Keyword.merge(configuration, slack: [])
+
+      assert {:error,
+              %Juvet.ConfigurationError{
+                message: "Slack signing secret missing in Juvet configuration."
+              }} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | configuration: config
+               })
+    end
+
+    test "returns an error if the Slack signature does not match", %{
+      context: %{request: request} = context,
+      timestamp: timestamp
+    } do
+      request = %{
+        request
+        | headers: [
+            {"x-slack-request-timestamp", timestamp},
+            {"x-slack-signature", "blah"}
+          ]
+      }
+
+      assert {:error,
+              %Juvet.InvalidRequestError{
+                message: "Invalid Slack request. Signature mismatch."
+              }} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | request: request
+               })
+    end
+  end
+end

--- a/test/juvet/middleware/slack/verify_request_test.exs
+++ b/test/juvet/middleware/slack/verify_request_test.exs
@@ -43,6 +43,19 @@ defmodule Juvet.Middleware.Slack.VerifyRequestTest do
       assert ctx[:request].verified?
     end
 
+    test "returns the context for a valid request when verifying is turned off",
+         %{context: %{configuration: configuration} = context} do
+      config = Keyword.merge(configuration, slack: [verify_requests: false])
+
+      assert {:ok, ctx} =
+               Juvet.Middleware.Slack.VerifyRequest.call(%{
+                 context
+                 | configuration: config
+               })
+
+      assert ctx[:request].verified?
+    end
+
     test "returns an error if the Slack timestamp header is not available", %{
       context: %{request: request} = context,
       signature: signature

--- a/test/juvet/middleware/slack/verify_request_test.exs
+++ b/test/juvet/middleware/slack/verify_request_test.exs
@@ -1,6 +1,7 @@
 defmodule Juvet.Middleware.Slack.VerifyRequestTest do
   use ExUnit.Case, async: true
   use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
 
   describe "call/1" do
     setup do
@@ -9,15 +10,9 @@ defmodule Juvet.Middleware.Slack.VerifyRequestTest do
 
       signing_secret = "646ed265b0d3bec1cf8e6bb03dbf5086"
       config = [slack: [signing_secret: signing_secret]]
-      timestamp = Juvet.GregorianDateTime.to_seconds() |> to_string
-      signature = "v0:#{timestamp}:#{body}"
 
-      signature =
-        "v0=#{
-          :crypto.mac(:hmac, :sha256, signing_secret, signature)
-          |> Base.encode16()
-        }"
-        |> String.downcase()
+      timestamp = generate_slack_timestamp()
+      signature = generate_slack_signature(params, signing_secret, timestamp)
 
       request =
         Juvet.Router.Request.new(%{

--- a/test/juvet/middleware/slack/verify_request_test.exs
+++ b/test/juvet/middleware/slack/verify_request_test.exs
@@ -8,7 +8,7 @@ defmodule Juvet.Middleware.Slack.VerifyRequestTest do
       params = %{"token" => "TOKEN", "team_id" => "T12345"}
       body = params |> URI.encode_query()
 
-      signing_secret = "646ed265b0d3bec1cf8e6bb03dbf5086"
+      signing_secret = generate_slack_signing_secret()
       config = [slack: [signing_secret: signing_secret]]
 
       timestamp = generate_slack_timestamp()

--- a/test/juvet/plug_test.exs
+++ b/test/juvet/plug_test.exs
@@ -2,6 +2,16 @@ defmodule Juvet.PlugTest do
   use ExUnit.Case, async: true
   use Juvet.PlugHelpers
 
+  describe "init/1" do
+    test "puts the options passed in private connection" do
+      conn = build_conn(:post, "/slack/commands")
+
+      conn = Juvet.Plug.call(conn, Juvet.Plug.init(foo: :bar))
+
+      assert conn.private[:juvet][:options][:foo] == :bar
+    end
+  end
+
   describe "POST /slack/commands" do
     test "responds with a 200 status" do
       conn = request!(:post, "/slack/commands")

--- a/test/juvet/plug_test.exs
+++ b/test/juvet/plug_test.exs
@@ -1,4 +1,4 @@
-defmodule Juvet.EndpointTest do
+defmodule Juvet.PlugTest do
   use ExUnit.Case, async: true
   use Juvet.PlugHelpers
 

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -1,47 +1,56 @@
 defmodule Juvet.Router.PlatformFactoryTest do
   use ExUnit.Case, async: true
 
-  describe "Juvet.Router.PlatformFactory.new/1" do
+  alias Juvet.Router.PlatformFactory
+
+  describe "new/1" do
     test "returns a SlackPlatform when the platform is slack" do
-      assert Juvet.Router.SlackPlatform ==
-               Juvet.Router.PlatformFactory.new(:slack)
+      platform = Juvet.Router.Platform.new(:slack)
+
+      assert %Juvet.Router.SlackPlatform{platform: platform} ==
+               PlatformFactory.new(platform)
     end
 
     test "returns an UnknownFactory when the platform is not recognized" do
-      assert %Juvet.Router.UnknownPlatform{platform: :blah} ==
-               Juvet.Router.PlatformFactory.new(:blah)
+      platform = Juvet.Router.Platform.new(:blah)
+
+      assert %Juvet.Router.UnknownPlatform{platform: platform} ==
+               PlatformFactory.new(platform)
     end
   end
 
-  describe "Juvet.Router.PlatformFactory.validate_route/3" do
+  describe "validate_route/3" do
     setup do
       route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+      platform = Juvet.Router.Platform.new(:slack)
 
-      [platform: Juvet.Router.SlackPlatform, route: route]
+      [platform: %Juvet.Router.SlackPlatform{platform: platform}, route: route]
     end
 
     test "delegates to the platform module", %{platform: platform, route: route} do
       assert {:ok, route} ==
-               Juvet.Router.PlatformFactory.validate_route(platform, route)
+               PlatformFactory.validate_route(platform, route)
     end
 
     test "returns an error if the route is not valid", %{platform: platform} do
       error_route = %Juvet.Router.Route{type: :blah}
 
-      assert {:error, {:unknown_route, [route: error_route, options: %{}]}} =
-               Juvet.Router.PlatformFactory.validate_route(
+      assert {:error,
+              {:unknown_route,
+               [platform: platform, route: error_route, options: %{}]}} =
+               PlatformFactory.validate_route(
                  platform,
                  error_route
                )
     end
 
     test "returns an error if the platform is not valid", %{route: route} do
-      unknown_platform = Juvet.Router.UnknownPlatform
+      unknown_platform = %Juvet.Router.UnknownPlatform{platform: :blah}
 
       assert {:error,
               {:unknown_platform,
                [platform: unknown_platform, route: route, options: %{}]}} =
-               Juvet.Router.PlatformFactory.validate_route(
+               PlatformFactory.validate_route(
                  unknown_platform,
                  route
                )

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -8,7 +8,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
     end
 
     test "returns an UnknownFactory when the platform is not recognized" do
-      assert Juvet.Router.UnknownPlatform ==
+      assert %Juvet.Router.UnknownPlatform{platform: :blah} ==
                Juvet.Router.PlatformFactory.new(:blah)
     end
   end
@@ -28,7 +28,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
     test "returns an error if the route is not valid", %{platform: platform} do
       error_route = %Juvet.Router.Route{type: :blah}
 
-      assert {:error, {:routing_error, _}} =
+      assert {:error, {:unknown_route, [route: error_route, options: %{}]}} =
                Juvet.Router.PlatformFactory.validate_route(
                  platform,
                  error_route
@@ -38,7 +38,9 @@ defmodule Juvet.Router.PlatformFactoryTest do
     test "returns an error if the platform is not valid", %{route: route} do
       unknown_platform = Juvet.Router.UnknownPlatform
 
-      assert {:error, {:routing_error, _}} =
+      assert {:error,
+              {:unknown_platform,
+               [platform: unknown_platform, route: route, options: %{}]}} =
                Juvet.Router.PlatformFactory.validate_route(
                  unknown_platform,
                  route

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -1,0 +1,15 @@
+defmodule Juvet.Router.PlatformFactoryTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.Router.PlatformFactory.new/1" do
+    test "returns a SlackPlatform when the platform is slack" do
+      assert Juvet.Router.SlackPlatform ==
+               Juvet.Router.PlatformFactory.new(:slack)
+    end
+
+    test "returns an UnknownFactory when the platform is not recognized" do
+      assert Juvet.Router.UnknownPlatform ==
+               Juvet.Router.PlatformFactory.new(:blah)
+    end
+  end
+end

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -12,4 +12,27 @@ defmodule Juvet.Router.PlatformFactoryTest do
                Juvet.Router.PlatformFactory.new(:blah)
     end
   end
+
+  describe "Juvet.Router.PlatformFactory.validate_route/3" do
+    setup do
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+
+      [platform: Juvet.Router.SlackPlatform, route: route]
+    end
+
+    test "delegates to the platform module", %{platform: platform, route: route} do
+      assert {:ok, route} ==
+               Juvet.Router.PlatformFactory.validate_route(platform, route)
+    end
+
+    test "returns an error if the route is not valid", %{platform: platform} do
+      error_route = %Juvet.Router.Route{type: :blah}
+
+      assert {:error, {:routing_error, _}} =
+               Juvet.Router.PlatformFactory.validate_route(
+                 platform,
+                 error_route
+               )
+    end
+  end
 end

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -34,5 +34,15 @@ defmodule Juvet.Router.PlatformFactoryTest do
                  error_route
                )
     end
+
+    test "returns an error if the platform is not valid", %{route: route} do
+      unknown_platform = Juvet.Router.UnknownPlatform
+
+      assert {:error, {:routing_error, _}} =
+               Juvet.Router.PlatformFactory.validate_route(
+                 unknown_platform,
+                 route
+               )
+    end
   end
 end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -1,6 +1,33 @@
 defmodule Juvet.Router.PlatformTest do
   use ExUnit.Case, async: true
 
+  describe "Juvet.Router.Platform.put_route/3" do
+    setup do
+      platform = Juvet.Router.Platform.new(:slack)
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+
+      [platform: platform, route: route]
+    end
+
+    test "returns an ok tuple with the route added to the returning platform",
+         %{platform: platform, route: route} do
+      assert {:ok, platform} = Juvet.Router.Platform.put_route(platform, route)
+      assert Enum.count(platform.routes) == 1
+      assert List.first(platform.routes).type == :command
+    end
+
+    test "returns an error tuple with the error from the returning platform", %{
+      platform: platform
+    } do
+      error_route = %Juvet.Router.Route{type: :blah}
+
+      assert {:error, error} =
+               Juvet.Router.Platform.put_route(platform, error_route)
+
+      assert error == {:routing_error, [route: error_route, options: %{}]}
+    end
+  end
+
   describe "Juvet.Router.Platform.validate_route/3" do
     setup do
       platform = Juvet.Router.Platform.new(:slack)

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -1,9 +1,11 @@
 defmodule Juvet.Router.PlatformTest do
   use ExUnit.Case, async: true
 
-  describe "Juvet.Router.Platform.put_route/3" do
+  alias Juvet.Router.Platform
+
+  describe "put_route/3" do
     setup do
-      platform = Juvet.Router.Platform.new(:slack)
+      platform = Platform.new(:slack)
       route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
 
       [platform: platform, route: route]
@@ -11,7 +13,7 @@ defmodule Juvet.Router.PlatformTest do
 
     test "returns an ok tuple with the route added to the returning platform",
          %{platform: platform, route: route} do
-      assert {:ok, platform} = Juvet.Router.Platform.put_route(platform, route)
+      assert {:ok, platform} = Platform.put_route(platform, route)
       assert Enum.count(platform.routes) == 1
       assert List.first(platform.routes).type == :command
     end
@@ -21,16 +23,63 @@ defmodule Juvet.Router.PlatformTest do
     } do
       error_route = %Juvet.Router.Route{type: :blah}
 
-      assert {:error, error} =
-               Juvet.Router.Platform.put_route(platform, error_route)
+      assert {:error, error} = Platform.put_route(platform, error_route)
 
-      assert error == {:unknown_route, [route: error_route, options: %{}]}
+      assert error ==
+               {:unknown_route,
+                [
+                  platform: %Juvet.Router.SlackPlatform{platform: platform},
+                  route: error_route,
+                  options: %{}
+                ]}
     end
   end
 
-  describe "Juvet.Router.Platform.validate_route/3" do
+  describe "find_route/2" do
     setup do
-      platform = Juvet.Router.Platform.new(:slack)
+      platform = Platform.new(:slack)
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+      {:ok, platform} = Platform.put_route(platform, route)
+
+      request = Juvet.Router.Request.new(%{params: %{"command" => "test"}})
+      request = %{request | platform: :slack, verified?: true}
+
+      [platform: platform, request: request]
+    end
+
+    test "returns an ok tuple with the route that were found", %{
+      platform: platform,
+      request: request
+    } do
+      assert {:ok, route} = Platform.find_route(platform, request)
+      assert route.type == :command
+      assert route.route == "/test"
+      assert route.options == [to: "controller#action"]
+    end
+
+    test "returns an error tuple with the route when the route is not found", %{
+      platform: platform,
+      request: request
+    } do
+      request = %{
+        request
+        | params: Map.merge(request.params, %{"command" => "/blah"})
+      }
+
+      assert {:error, error} = Platform.find_route(platform, request)
+
+      assert error ==
+               {:unknown_route,
+                [
+                  platform: %Juvet.Router.SlackPlatform{platform: platform},
+                  request: request
+                ]}
+    end
+  end
+
+  describe "validate_route/3" do
+    setup do
+      platform = Platform.new(:slack)
       route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
 
       [platform: platform, route: route]
@@ -40,8 +89,7 @@ defmodule Juvet.Router.PlatformTest do
       platform: platform,
       route: route
     } do
-      assert {:ok, route} =
-               Juvet.Router.Platform.validate_route(platform, route)
+      assert {:ok, route} = Platform.validate_route(platform, route)
     end
 
     test "returns an error tuple with the route when the route is not valid", %{
@@ -49,8 +97,14 @@ defmodule Juvet.Router.PlatformTest do
     } do
       error_route = %Juvet.Router.Route{type: :blah}
 
-      assert {:error, {:unknown_route, [route: error_route, options: %{}]}} ==
-               Juvet.Router.Platform.validate_route(platform, error_route)
+      assert {:error,
+              {:unknown_route,
+               [
+                 platform: %Juvet.Router.SlackPlatform{platform: platform},
+                 route: error_route,
+                 options: %{}
+               ]}} ==
+               Platform.validate_route(platform, error_route)
     end
   end
 end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -1,0 +1,20 @@
+defmodule Juvet.Router.PlatformTest do
+  use ExUnit.Case, async: true
+
+  describe "Juvet.Router.Platform.validate_route/3" do
+    setup do
+      platform = Juvet.Router.Platform.new(:slack)
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+
+      [platform: platform, route: route]
+    end
+
+    test "returns an ok tuple with the route when the route is valid to add", %{
+      platform: platform,
+      route: route
+    } do
+      assert {:ok, route} =
+               Juvet.Router.Platform.validate_route(platform, route)
+    end
+  end
+end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -24,7 +24,7 @@ defmodule Juvet.Router.PlatformTest do
       assert {:error, error} =
                Juvet.Router.Platform.put_route(platform, error_route)
 
-      assert error == {:routing_error, [route: error_route, options: %{}]}
+      assert error == {:unknown_route, [route: error_route, options: %{}]}
     end
   end
 
@@ -49,7 +49,7 @@ defmodule Juvet.Router.PlatformTest do
     } do
       error_route = %Juvet.Router.Route{type: :blah}
 
-      assert {:error, {:routing_error, [route: error_route, options: %{}]}} ==
+      assert {:error, {:unknown_route, [route: error_route, options: %{}]}} ==
                Juvet.Router.Platform.validate_route(platform, error_route)
     end
   end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -16,5 +16,14 @@ defmodule Juvet.Router.PlatformTest do
       assert {:ok, route} =
                Juvet.Router.Platform.validate_route(platform, route)
     end
+
+    test "returns an error tuple with the route when the route is not valid", %{
+      platform: platform
+    } do
+      error_route = %Juvet.Router.Route{type: :blah}
+
+      assert {:error, {:routing_error, [route: error_route, options: %{}]}} ==
+               Juvet.Router.Platform.validate_route(platform, error_route)
+    end
   end
 end

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -21,6 +21,7 @@ defmodule Juvet.Router.RequestTest do
       assert request.params == %{"foo" => :bar}
       assert request.path == "/slack/commands"
       assert request.port == 80
+      assert request.private
       assert request.query_string == ""
       assert request.scheme == :http
       assert request.status == 200

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -2,13 +2,13 @@ defmodule Juvet.Router.RequestTest do
   use ExUnit.Case, async: true
   use Juvet.PlugHelpers
 
+  setup_all do
+    conn = request!(:post, "/slack/commands", %{foo: :bar})
+
+    [conn: conn]
+  end
+
   describe "new/1" do
-    setup do
-      conn = request!(:post, "/slack/commands", %{foo: :bar})
-
-      [conn: conn]
-    end
-
     test "returns a structure from the conn", %{conn: conn} do
       request = Juvet.Router.Request.new(conn)
 
@@ -24,6 +24,21 @@ defmodule Juvet.Router.RequestTest do
       assert request.query_string == ""
       assert request.scheme == :http
       assert request.status == 200
+    end
+  end
+
+  describe "get_header/2" do
+    setup %{conn: conn} do
+      [request: Juvet.Router.Request.new(conn)]
+    end
+
+    test "returns the header values if found", %{request: request} do
+      assert Juvet.Router.Request.get_header(request, "content-type") ==
+               ["multipart/mixed; boundary=plug_conn_test"]
+    end
+
+    test "returns an empty list of none found", %{request: request} do
+      assert Juvet.Router.Request.get_header(request, "blah") == []
     end
   end
 end

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -25,6 +25,7 @@ defmodule Juvet.Router.RequestTest do
       assert request.query_string == ""
       assert request.scheme == :http
       assert request.status == 200
+      refute request.verified?
     end
   end
 

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -1,4 +1,4 @@
-defmodule Juvet.Middleware.RequestTest do
+defmodule Juvet.Router.RequestTest do
   use ExUnit.Case, async: true
   use Juvet.PlugHelpers
 
@@ -10,7 +10,7 @@ defmodule Juvet.Middleware.RequestTest do
     end
 
     test "returns a structure from the conn", %{conn: conn} do
-      request = Juvet.Middleware.Request.new(conn)
+      request = Juvet.Router.Request.new(conn)
 
       assert request.headers == [
                {"content-type", "multipart/mixed; boundary=plug_conn_test"}

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -25,6 +25,7 @@ defmodule Juvet.Router.RequestTest do
       assert request.query_string == ""
       assert request.scheme == :http
       assert request.status == 200
+      assert request.platform == :unknown
       refute request.verified?
     end
   end

--- a/test/juvet/router/route_finder_test.exs
+++ b/test/juvet/router/route_finder_test.exs
@@ -1,0 +1,42 @@
+defmodule Juvet.Router.RouteFinderTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.Router.RouteFinder
+
+  describe "find/2" do
+    setup do
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+
+      {:ok, platform} =
+        Juvet.Router.Platform.new(:slack)
+        |> Juvet.Router.Platform.put_route(route)
+
+      request = Juvet.Router.Request.new(%{params: %{"command" => "test"}})
+      request = %{request | platform: :slack, verified?: true}
+
+      [platforms: [platform], request: request]
+    end
+
+    test "returns an ok tuple with the route if it was found", %{
+      platforms: platforms,
+      request: request
+    } do
+      assert {:ok, route} = RouteFinder.find(platforms, request)
+      assert route.type == :command
+      assert route.route == "/test"
+      assert route.options == [to: "controller#action"]
+    end
+
+    test "returns an error tuple with an error if the route was not found", %{
+      platforms: platforms,
+      request: request
+    } do
+      request = %{
+        request
+        | params: Map.merge(request.params, %{"command" => "blah"})
+      }
+
+      assert {:error, :not_found} = RouteFinder.find(platforms, request)
+    end
+  end
+end

--- a/test/juvet/router/route_test.exs
+++ b/test/juvet/router/route_test.exs
@@ -1,0 +1,19 @@
+defmodule Juvet.Router.RouteTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.Router.Route
+
+  describe "path/1" do
+    test "returns the path from the options" do
+      route = Route.new(:command, "/test", to: "controller#action")
+
+      assert Route.path(route) == "controller#action"
+    end
+
+    test "returns nil if the option does not exist" do
+      route = Route.new(:command, "/test")
+
+      assert is_nil(Route.path(route))
+    end
+  end
+end

--- a/test/juvet/router/slack_platform_test.exs
+++ b/test/juvet/router/slack_platform_test.exs
@@ -1,0 +1,54 @@
+defmodule Juvet.Router.SlackPlatformTest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.Router.SlackPlatform
+
+  describe "find_route/2" do
+    setup do
+      route = Juvet.Router.Route.new(:command, "/test", to: "controller#action")
+
+      {:ok, platform} =
+        Juvet.Router.Platform.new(:slack)
+        |> Juvet.Router.Platform.put_route(route)
+
+      platform = Juvet.Router.SlackPlatform.new(platform)
+
+      request = Juvet.Router.Request.new(%{params: %{"command" => "test"}})
+      request = %{request | platform: :slack, verified?: true}
+
+      [platform: platform, request: request]
+    end
+
+    test "returns an ok tuple with the route if the request is a verified Slack command request",
+         %{platform: platform, request: request} do
+      assert {:ok, route} = SlackPlatform.find_route(platform, request)
+      assert route.type == :command
+      assert route.route == "/test"
+      assert route.options == [to: "controller#action"]
+    end
+
+    test "returns an error tuple with an unverified request", %{
+      platform: platform,
+      request: request
+    } do
+      request = %{request | verified?: false}
+
+      assert {:error,
+              {:unverified_route, [platform: platform, request: request]}} =
+               SlackPlatform.find_route(platform, request)
+    end
+
+    test "returns an error tuple if the request is not found", %{
+      platform: platform,
+      request: request
+    } do
+      request = %{
+        request
+        | params: Map.merge(request.params, %{"command" => "/blah"})
+      }
+
+      assert {:error, {:unknown_route, [platform: platform, request: request]}} =
+               SlackPlatform.find_route(platform, request)
+    end
+  end
+end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -1,0 +1,24 @@
+defmodule Juvet.RouterTest do
+  use ExUnit.Case, async: true
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      # command("/test", to: "controller#action")
+    end
+  end
+
+  describe "Juvet.Router.platform/2" do
+    test "accumulates the platforms within the router" do
+      platforms = Juvet.Router.platforms(MyRouter)
+
+      IO.puts("******************")
+      IO.inspect(platforms)
+      IO.puts("******************")
+
+      assert Enum.count(platforms) == 1
+      assert Enum.first(platforms).platform == :slack
+    end
+  end
+end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -21,7 +21,7 @@ defmodule Juvet.RouterTest do
       platforms = Juvet.Router.platforms(MyRouter)
 
       assert Enum.count(List.first(platforms).routes) == 1
-      assert List.first(List.first(platforms).routes).command == "/test"
+      assert List.first(List.first(platforms).routes).route == "/test"
     end
   end
 end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -16,5 +16,12 @@ defmodule Juvet.RouterTest do
       assert Enum.count(platforms) == 1
       assert List.first(platforms).platform == :slack
     end
+
+    test "accumulates the routes within the router" do
+      platforms = Juvet.Router.platforms(MyRouter)
+
+      assert Enum.count(List.first(platforms).routes) == 1
+      assert List.first(List.first(platforms).routes).command == "/test"
+    end
   end
 end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -9,6 +9,20 @@ defmodule Juvet.RouterTest do
     end
   end
 
+  describe "compile time validations" do
+    test "invalid platform raises RouteError" do
+      assert_raise Juvet.Router.RouteError,
+                   "Platform `blah` is not valid.",
+                   fn ->
+                     defmodule MyBadRouter do
+                       use Juvet.Router
+
+                       platform(:blah, do: nil)
+                     end
+                   end
+    end
+  end
+
   describe "Juvet.Router.platform/2" do
     test "accumulates the platforms within the router" do
       platforms = Juvet.Router.platforms(MyRouter)

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -51,7 +51,7 @@ defmodule Juvet.RouterTest do
 
   describe "find_route/2" do
     test "returns an ok tuple with the route if it was found" do
-      request = Juvet.Router.Request.new(%{params: %{"command" => "test"}})
+      request = Juvet.Router.Request.new(%{params: %{"command" => "/test"}})
       request = %{request | platform: :slack, verified?: true}
 
       assert {:ok, route} = Juvet.Router.find_route(MyRouter, request)
@@ -59,7 +59,7 @@ defmodule Juvet.RouterTest do
     end
 
     test "returns an error tuple if it was not found" do
-      request = Juvet.Router.Request.new(%{params: %{"command" => "blah"}})
+      request = Juvet.Router.Request.new(%{params: %{"command" => "/blah"}})
       request = %{request | platform: :slack, verified?: true}
 
       assert {:error, :not_found} = Juvet.Router.find_route(MyRouter, request)

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -23,7 +23,7 @@ defmodule Juvet.RouterTest do
     end
   end
 
-  describe "Juvet.Router.platform/2" do
+  describe "platform/2" do
     test "accumulates the platforms within the router" do
       platforms = Juvet.Router.platforms(MyRouter)
 
@@ -36,6 +36,23 @@ defmodule Juvet.RouterTest do
 
       assert Enum.count(List.first(platforms).routes) == 1
       assert List.first(List.first(platforms).routes).route == "/test"
+    end
+  end
+
+  describe "find_route/2" do
+    test "returns an ok tuple with the route if it was found" do
+      request = Juvet.Router.Request.new(%{params: %{"command" => "test"}})
+      request = %{request | platform: :slack, verified?: true}
+
+      assert {:ok, route} = Juvet.Router.find_route(MyRouter, request)
+      assert route.options == [to: "controller#action"]
+    end
+
+    test "returns an error tuple if it was not found" do
+      request = Juvet.Router.Request.new(%{params: %{"command" => "blah"}})
+      request = %{request | platform: :slack, verified?: true}
+
+      assert {:error, :not_found} = Juvet.Router.find_route(MyRouter, request)
     end
   end
 end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -5,7 +5,7 @@ defmodule Juvet.RouterTest do
     use Juvet.Router
 
     platform :slack do
-      # command("/test", to: "controller#action")
+      command("/test", to: "controller#action")
     end
   end
 
@@ -13,12 +13,8 @@ defmodule Juvet.RouterTest do
     test "accumulates the platforms within the router" do
       platforms = Juvet.Router.platforms(MyRouter)
 
-      IO.puts("******************")
-      IO.inspect(platforms)
-      IO.puts("******************")
-
       assert Enum.count(platforms) == 1
-      assert Enum.first(platforms).platform == :slack
+      assert List.first(platforms).platform == :slack
     end
   end
 end

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -23,6 +23,16 @@ defmodule Juvet.RouterTest do
     end
   end
 
+  describe "exists?/1" do
+    test "returns true if the router is defined" do
+      assert Juvet.Router.exists?(MyRouter)
+    end
+
+    test "returns false if the router is defined" do
+      refute Juvet.Router.exists?(Blah)
+    end
+  end
+
   describe "platform/2" do
     test "accumulates the platforms within the router" do
       platforms = Juvet.Router.platforms(MyRouter)

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -7,7 +7,7 @@ defmodule Juvet.RunnerTest do
     use Juvet.Router
 
     platform :slack do
-      command("/test", to: "test_controller#action")
+      command("/test", to: "juvet.runner_test.test#action")
     end
   end
 
@@ -122,7 +122,7 @@ defmodule Juvet.RunnerTest do
     } do
       {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
 
-      assert Map.fetch!(context, :path) == "test_controller#action"
+      assert Map.fetch!(context, :path) == "juvet.runner_test.test#action"
     end
   end
 end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -1,5 +1,15 @@
 defmodule Juvet.RunnerTest do
   use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      command("/test", to: "test_controller#action")
+    end
+  end
 
   defmodule TestController do
     def action(%{pid: pid}) do
@@ -10,9 +20,17 @@ defmodule Juvet.RunnerTest do
     end
   end
 
-  describe "Juvet.Runner.route/2" do
+  describe "route/2" do
     setup do
       [path: "juvet.runner_test.test#action"]
+    end
+
+    test "can merge with the default configuration by adding a configuration option",
+         %{path: path} do
+      {:ok, context} =
+        Juvet.Runner.route(path, %{configuration: [router: MyRouter]})
+
+      assert Keyword.get(context[:configuration], :router) == MyRouter
     end
 
     test "adds the configuration to the context", %{path: path} do
@@ -44,6 +62,67 @@ defmodule Juvet.RunnerTest do
       {:ok, _context} = Juvet.Runner.route(path, %{pid: self()})
 
       assert_received :called_controller
+    end
+  end
+
+  describe "run/2" do
+    setup do
+      params = %{"command" => "test", "team_id" => "T12345"}
+      signing_secret = generate_slack_signing_secret()
+      config = [router: MyRouter, slack: [signing_secret: signing_secret]]
+
+      conn =
+        %Plug.Conn{
+          req_headers: slack_headers(params, signing_secret),
+          method: "POST",
+          params: params,
+          request_path: "/slack/commands",
+          status: 200
+        }
+        |> put_raw_body()
+
+      [conn: conn, config: config, params: params]
+    end
+
+    test "can merge with the default configuration by adding a configuration option",
+         %{conn: conn, config: config} do
+      {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
+
+      assert Keyword.get(context[:configuration], :router) == MyRouter
+    end
+
+    test "adds the conn to the context", %{conn: conn, config: config} do
+      {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
+
+      assert Map.fetch!(context, :conn) == conn
+    end
+
+    test "adds the current values in the context", %{conn: conn, config: config} do
+      {:ok, context} =
+        Juvet.Runner.run(conn, %{blah: "bleh", configuration: config})
+
+      assert Map.fetch!(context, :blah) == "bleh"
+    end
+
+    test "parses the request into a request struct", %{
+      conn: conn,
+      config: config
+    } do
+      {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
+
+      assert Map.fetch!(context, :request).params == %{
+               "command" => "test",
+               "team_id" => "T12345"
+             }
+    end
+
+    test "finds the route that needs to be called", %{
+      conn: conn,
+      config: config
+    } do
+      {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
+
+      assert Map.fetch!(context, :path) == "test_controller#action"
     end
   end
 end

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -67,7 +67,7 @@ defmodule Juvet.RunnerTest do
 
   describe "run/2" do
     setup do
-      params = %{"command" => "test", "team_id" => "T12345"}
+      params = %{"command" => "/test", "team_id" => "T12345"}
       signing_secret = generate_slack_signing_secret()
       config = [router: MyRouter, slack: [signing_secret: signing_secret]]
 
@@ -111,7 +111,7 @@ defmodule Juvet.RunnerTest do
       {:ok, context} = Juvet.Runner.run(conn, %{configuration: config})
 
       assert Map.fetch!(context, :request).params == %{
-               "command" => "test",
+               "command" => "/test",
                "team_id" => "T12345"
              }
     end

--- a/test/support/configuration_helpers.ex
+++ b/test/support/configuration_helpers.ex
@@ -9,8 +9,9 @@ defmodule Juvet.ConfigurationHelpers do
     [
       bot: MyBot,
       slack: [
-        events_endpoint: "/slack/events",
-        actions_endpoint: "/slack/actions"
+        actions_endpoint: "/slack/actions",
+        commands_endpoint: "/slack/commands",
+        events_endpoint: "/slack/events"
       ]
     ]
   end

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -7,21 +7,35 @@ defmodule Juvet.PlugHelpers do
     quote do
       use Plug.Test
 
+      alias Plug.Conn
+
       defp request!(method, path, params_or_body \\ nil, headers \\ nil) do
-        conn(method, path, params_or_body)
-        |> put_request_headers(headers)
+        build_conn(method, path, params_or_body, headers)
         |> Juvet.Plug.call(Juvet.Plug.init([]))
+        |> from_set_to_sent()
       end
 
-      defp put_request_headers(conn, nil), do: conn
-
-      defp put_request_headers(conn, headers) do
-        Enum.each(headers, fn {key, value} ->
-          conn = conn |> put_req_header(to_string(key), value)
-        end)
-
-        conn
+      defp build_conn(method, path, params_or_body, nil) do
+        Plug.Adapters.Test.Conn.conn(
+          %Conn{},
+          method,
+          path,
+          params_or_body
+        )
       end
+
+      defp build_conn(method, path, params_or_body, headers) do
+        Plug.Adapters.Test.Conn.conn(
+          %Conn{req_headers: headers},
+          method,
+          path,
+          params_or_body
+        )
+      end
+
+      defp from_set_to_sent(%Conn{state: :set} = conn), do: Conn.send_resp(conn)
+
+      defp from_set_to_sent(conn), do: conn
     end
   end
 end

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -1,0 +1,16 @@
+defmodule Juvet.PlugHelpers do
+  @moduledoc """
+  Test helpers for testing Plug tests.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      use Plug.Test
+
+      defp request!(method, path, params_or_body \\ nil) do
+        conn(method, path, params_or_body)
+        |> Juvet.EndpointRouter.call(Juvet.EndpointRouter.init([]))
+      end
+    end
+  end
+end

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -9,6 +9,12 @@ defmodule Juvet.PlugHelpers do
 
       alias Plug.Conn
 
+      def put_raw_body(%{params: params} = conn) do
+        Plug.Conn.put_private(conn, :juvet, %{
+          raw_body: params |> URI.encode_query()
+        })
+      end
+
       defp request!(method, path, params_or_body \\ nil, headers \\ nil) do
         build_conn(method, path, params_or_body, headers)
         |> Juvet.Plug.call(Juvet.Plug.init([]))

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -9,19 +9,18 @@ defmodule Juvet.PlugHelpers do
 
       alias Plug.Conn
 
+      def put_raw_body(%{params: %Plug.Conn.Unfetched{aspect: :params}} = conn),
+        do: conn
+
       def put_raw_body(%{params: params} = conn) do
         Plug.Conn.put_private(conn, :juvet, %{
           raw_body: params |> URI.encode_query()
         })
       end
 
-      defp request!(method, path, params_or_body \\ nil, headers \\ nil) do
-        build_conn(method, path, params_or_body, headers)
-        |> Juvet.Plug.call(Juvet.Plug.init([]))
-        |> from_set_to_sent()
-      end
+      def build_conn(method, path, params_or_body \\ nil, headers \\ nil)
 
-      defp build_conn(method, path, params_or_body, nil) do
+      def build_conn(method, path, params_or_body, nil) do
         Plug.Adapters.Test.Conn.conn(
           %Conn{},
           method,
@@ -30,13 +29,26 @@ defmodule Juvet.PlugHelpers do
         )
       end
 
-      defp build_conn(method, path, params_or_body, headers) do
+      def build_conn(method, path, params_or_body, headers) do
         Plug.Adapters.Test.Conn.conn(
           %Conn{req_headers: headers},
           method,
           path,
           params_or_body
         )
+      end
+
+      def request!(
+            method,
+            path,
+            params_or_body \\ nil,
+            headers \\ nil,
+            init_opts \\ []
+          ) do
+        build_conn(method, path, params_or_body, headers)
+        |> put_raw_body()
+        |> Juvet.Plug.call(Juvet.Plug.init(init_opts))
+        |> from_set_to_sent()
       end
 
       defp from_set_to_sent(%Conn{state: :set} = conn), do: Conn.send_resp(conn)

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -7,9 +7,20 @@ defmodule Juvet.PlugHelpers do
     quote do
       use Plug.Test
 
-      defp request!(method, path, params_or_body \\ nil) do
+      defp request!(method, path, params_or_body \\ nil, headers \\ nil) do
         conn(method, path, params_or_body)
+        |> put_request_headers(headers)
         |> Juvet.EndpointRouter.call(Juvet.EndpointRouter.init([]))
+      end
+
+      defp put_request_headers(conn, nil), do: conn
+
+      defp put_request_headers(conn, headers) do
+        Enum.each(headers, fn {key, value} ->
+          conn = conn |> put_req_header(to_string(key), value)
+        end)
+
+        conn
       end
     end
   end

--- a/test/support/plug_helpers.ex
+++ b/test/support/plug_helpers.ex
@@ -10,7 +10,7 @@ defmodule Juvet.PlugHelpers do
       defp request!(method, path, params_or_body \\ nil, headers \\ nil) do
         conn(method, path, params_or_body)
         |> put_request_headers(headers)
-        |> Juvet.EndpointRouter.call(Juvet.EndpointRouter.init([]))
+        |> Juvet.Plug.call(Juvet.Plug.init([]))
       end
 
       defp put_request_headers(conn, nil), do: conn

--- a/test/support/slack_request_helpers.ex
+++ b/test/support/slack_request_helpers.ex
@@ -5,6 +5,24 @@ defmodule Juvet.SlackRequestHelpers do
 
   defmacro __using__(_) do
     quote do
+      def slack_headers(
+            params,
+            signing_secret \\ generate_slack_signing_secret(),
+            timestamp \\ NaiveDateTime.utc_now()
+          ) do
+        signature = generate_slack_signature(params, signing_secret, timestamp)
+        timestamp = generate_slack_timestamp(timestamp)
+
+        [
+          {"x-slack-request-timestamp", timestamp},
+          {"x-slack-signature", signature}
+        ]
+      end
+
+      def generate_slack_signing_secret do
+        :crypto.strong_rand_bytes(32)
+      end
+
       def generate_slack_signature(
             params,
             signing_secret,

--- a/test/support/slack_request_helpers.ex
+++ b/test/support/slack_request_helpers.ex
@@ -1,0 +1,25 @@
+defmodule Juvet.SlackRequestHelpers do
+  @moduledoc """
+  Test helpers for making Slack requests.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      def generate_slack_signature(
+            params,
+            signing_secret,
+            timestamp \\ NaiveDateTime.utc_now()
+          ) do
+        params
+        |> URI.encode_query()
+        |> Juvet.SlackSigningSecret.generate(signing_secret, timestamp)
+      end
+
+      def generate_slack_timestamp(date_time \\ NaiveDateTime.utc_now()) do
+        date_time
+        |> Juvet.GregorianDateTime.to_seconds()
+        |> to_string
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR represents a culmination of work that is the base work needed for a full request from a Slack command -> calling a function on a controller.

Highlights:

* A router (`Juvet.Router`) that contains macros to describe the routes for a bot
* A new `Plug` that will allow Juvet to process requests from plug-friendly apps like a Phoenix app
* `Juvet.Runner.run/2` with a `Plug.Conn` will route a request through middleware
* New middleware to create a `Juvet.Router.Request` based on the `conn` struct
* New middleware to identify a request as a slack or unknown request type
* New middleware to verify a request comes from Slack
* New middleware to route the request based on the parameters for Slack. Works with Slack commands right now
* Compile-time validations of the route

Closes #41 