### PR TITLE
Fix request parsing

### DIFF
--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -23,6 +23,7 @@ defmodule Juvet.Plug do
 
   plug(Plug.Parsers,
     parsers: [:json, :multipart, :urlencoded],
+    pass: ["*/*"],
     body_reader: {Juvet.CacheBodyReader, :read_body, []},
     json_decoder: Poison
   )


### PR DESCRIPTION
This PR fixes an issue where the `Juvet.Plug` would raise `UnsupportedMediaTypeError` when the request did not have a `content-type` that matched the parsers. This occurred when the client application supported GraphQL requests.