### PR TITLE
Fix API Body Formatting

### DIFF
--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -20,7 +20,7 @@ defmodule Juvet.SlackAPI.Chat do
   } = Juvet.SlackAPI.Chat.post_message(%{token: token, channel: channel, text: text})
   """
   def post_message(options \\ %{}) do
-    {_, options} = options |> Map.get_and_update(:blocks, &{&1, Poison.encode!(&1)})
+    options = options |> transform_options
 
     SlackAPI.make_request("chat.postMessage", options)
     |> SlackAPI.render_response()
@@ -42,9 +42,20 @@ defmodule Juvet.SlackAPI.Chat do
   } = Juvet.SlackAPI.Chat.update(%{token: token, channel: channel, text: text, ts: timestamp})
   """
   def update(options \\ %{}) do
-    {_, options} = options |> Map.get_and_update(:blocks, &{&1, Poison.encode!(&1)})
+    options = options |> transform_options
 
     SlackAPI.make_request("chat.update", options)
     |> SlackAPI.render_response()
+  end
+
+  defp encode_blocks(nil), do: nil
+  defp encode_blocks(blocks), do: Poison.encode!(blocks)
+
+  defp transform_options(options) do
+    options
+    |> Map.get_and_update(:blocks, &{&1, encode_blocks(&1)})
+    |> elem(1)
+    |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -27,9 +27,12 @@ defmodule Juvet.SlackAPI.Conversations do
     |> SlackAPI.render_response()
   end
 
+  defp encode_users(nil), do: nil
+  defp encode_users(users), do: Enum.join(users, ",")
+
   defp transform_options(options) do
     options
-    |> Map.get_and_update(:users, &{&1, Enum.join(&1, ",")})
+    |> Map.get_and_update(:users, &{&1, encode_users(&1)})
     |> elem(1)
     |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
     |> Enum.into(%{})

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -21,9 +21,17 @@ defmodule Juvet.SlackAPI.Conversations do
   """
 
   def open(options \\ %{}) do
-    {_, options} = options |> Map.get_and_update(:users, &{&1, Poison.encode!(&1)})
+    options = options |> transform_options
 
     SlackAPI.make_request("conversations.open", options)
     |> SlackAPI.render_response()
+  end
+
+  defp transform_options(options) do
+    options
+    |> Map.get_and_update(:users, &{&1, Enum.join(&1, ",")})
+    |> elem(1)
+    |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
+    |> Enum.into(%{})
   end
 end


### PR DESCRIPTION
This PR fixes two issues with the API calls, specifically with formatting complex arguments for the bodies.

For `conversations.open`, we encode the list of users as a string array instead of JSON encoding them as that caused `user not found` issues in the API calls

For `chat.postMessage` and `chat.update`, the `blocks` is not passed as a `null` string if the parameter was not specified.
