### PR TITLE
Router for Actions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :juvet,
   slack: [
+    actions_endpoint: "/slack/actions",
     commands_endpoint: "/slack/commands",
     events_endpoint: "/slack/events"
   ]

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -1,24 +1,6 @@
 defmodule Juvet.Router do
-  alias Juvet.Router.{Platform, Route, RouteFinder}
-
-  defmodule RouteError do
-    @moduledoc """
-    Exception raised when an exception is found within a route..
-    """
-    defexception status: 404,
-                 message: "invalid route",
-                 router: nil
-
-    def exception(opts) do
-      message = Keyword.fetch!(opts, :message)
-      router = Keyword.fetch!(opts, :router)
-
-      %RouteError{
-        message: message,
-        router: router
-      }
-    end
-  end
+  alias Juvet.Router
+  alias Juvet.Router.{Route, RouteFinder}
 
   defmacro __using__(_opts) do
     quote do
@@ -30,15 +12,14 @@ defmodule Juvet.Router do
     quote do
       import unquote(__MODULE__)
 
-      Module.register_attribute(__MODULE__, :juvet_platforms, accumulate: true)
-
+      Router.State.init(__MODULE__)
       @before_compile unquote(__MODULE__)
     end
   end
 
   @doc false
   defmacro __before_compile__(env) do
-    platforms = env.module |> Module.get_attribute(:juvet_platforms)
+    platforms = env.module |> Router.State.get_platforms()
 
     quote do
       def __platforms__, do: unquote(Macro.escape(platforms))
@@ -46,73 +27,27 @@ defmodule Juvet.Router do
   end
 
   defmacro action(action, options \\ []) do
-    IO.puts("adding action...")
-
     quote do
-      Route.new(:action, unquote(action), unquote(options))
+      Router.State.put_route_on_top!(
+        __MODULE__,
+        Route.new(:action, unquote(action), unquote(options))
+      )
     end
   end
 
   defmacro command(command, options \\ []) do
-    IO.puts("adding command...")
-
     quote do
-      Route.new(:command, unquote(command), unquote(options))
+      Router.State.put_route_on_top!(
+        __MODULE__,
+        Route.new(:command, unquote(command), unquote(options))
+      )
     end
   end
 
   defmacro platform(platform, do: block) do
-    # I Don't think this is the way to do it all
-    # We need to add a context to the current platform and allow the `command`, `action`, etc. to work off of the
-    # current platform in the context. I believe this is what scope -> routes do in Phoenix?
-    """
-    routes =
-      case Macro.decompose_call(block) do
-        :error -> []
-        {_name, routes} -> routes
-      end
-
-      add_platform(platform, routes)
-    """
-
-    """
-    block =
-      quote do
-        unquote(block)
-      end
-    """
-
     quote do
-      IO.puts("unquote the block first")
-      # routes = [unquote(block)] |> IO.inspect()
-      routes = []
-
-      IO.puts("unquoted...")
-
-      case Platform.new(unquote(platform)) |> Platform.validate() do
-        {:ok, platform} ->
-          platform =
-            Enum.reduce(routes, platform, fn route, platform ->
-              case Platform.put_route(platform, route) do
-                {:ok, platform} ->
-                  platform
-
-                {:error, {:unknown_platform, route_info}} ->
-                  platform = Keyword.fetch!(route_info, :platform)
-
-                  raise RouteError,
-                    message: "Platform `#{platform.platform.platform}` is not valid.",
-                    router: __MODULE__
-              end
-            end)
-
-          @juvet_platforms platform
-
-        {:error, :unknown_platform} ->
-          raise RouteError,
-            message: "Platform `#{unquote(platform)}` is not valid.",
-            router: __MODULE__
-      end
+      Router.State.put_platform!(__MODULE__, unquote(platform))
+      unquote(block)
     end
   end
 
@@ -128,36 +63,5 @@ defmodule Juvet.Router do
 
   def platforms(router) do
     router.__platforms__()
-  end
-
-  defp add_platform(platform, routes) do
-    IO.inspect(routes, label: "routes")
-
-    quote do
-      case Platform.new(unquote(platform)) |> Platform.validate() do
-        {:ok, platform} ->
-          platform =
-            Enum.reduce(unquote(routes), platform, fn route, platform ->
-              case Platform.put_route(platform, route) do
-                {:ok, platform} ->
-                  platform
-
-                {:error, {:unknown_platform, route_info}} ->
-                  platform = Keyword.fetch!(route_info, :platform)
-
-                  raise RouteError,
-                    message: "Platform `#{platform.platform.platform}` is not valid.",
-                    router: __MODULE__
-              end
-            end)
-
-          @juvet_platforms platform
-
-        {:error, :unknown_platform} ->
-          raise RouteError,
-            message: "Platform `#{unquote(platform)}` is not valid.",
-            router: __MODULE__
-      end
-    end
   end
 end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -45,6 +45,12 @@ defmodule Juvet.Router do
     end
   end
 
+  defmacro action(action, options \\ []) do
+    quote do
+      Route.new(:action, unquote(action), unquote(options))
+    end
+  end
+
   defmacro command(command, options \\ []) do
     quote do
       Route.new(:command, unquote(command), unquote(options))

--- a/lib/juvet/router/conn.ex
+++ b/lib/juvet/router/conn.ex
@@ -17,6 +17,19 @@ defmodule Juvet.Router.Conn do
 
   def private_key, do: @private_key
 
+  def run(conn) do
+    config = get_config(conn)
+    context = get_context(conn)
+
+    case Juvet.Runner.run(conn, Map.merge(%{configuration: config}, context)) do
+      {:ok, context} ->
+        maybe_send_response(context)
+
+      {:error, error} ->
+        send_error(conn, error)
+    end
+  end
+
   def send_resp(%{conn: conn, response: %{body: body, status: status}}, options \\ []) do
     halt = Keyword.get(options, :halt, true)
 
@@ -24,6 +37,27 @@ defmodule Juvet.Router.Conn do
     |> maybe_halt(halt)
   end
 
+  defp get_config(%Plug.Conn{} = conn), do: get_config(get_private(conn))
+
+  defp get_config(%{options: options}) do
+    get_in(options, [:configuration]) || []
+  end
+
+  defp get_config(_), do: []
+
+  defp get_context(%Plug.Conn{} = conn), do: get_context(get_private(conn))
+
+  defp get_context(%{options: options}) do
+    get_in(options, [:context]) || %{}
+  end
+
   defp maybe_halt(conn, false), do: conn
   defp maybe_halt(conn, true), do: conn |> Plug.Conn.halt()
+
+  defp maybe_send_response(%{conn: %{state: :chunked} = conn}), do: conn
+  defp maybe_send_response(%{conn: %{state: :sent} = conn}), do: conn
+
+  defp maybe_send_response(%{conn: _conn} = context), do: send_resp(context)
+
+  defp send_error(conn, _error), do: conn |> Plug.Conn.send_resp(200, "")
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -26,6 +26,10 @@ defmodule Juvet.Router.Platform do
     PlatformFactory.new(platform) |> PlatformFactory.find_route(request)
   end
 
+  def validate(platform) do
+    PlatformFactory.new(platform) |> PlatformFactory.validate()
+  end
+
   def validate_route(platform, route, options \\ %{}) do
     PlatformFactory.new(platform)
     |> PlatformFactory.validate_route(route, options)

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -28,6 +28,8 @@ defmodule Juvet.Router.PlatformFactory do
     platform |> platform.find_route(request)
   end
 
+  def validate(%{__struct__: struct} = platform), do: struct.validate(platform)
+
   def validate_route(platform, route, options \\ %{})
 
   def validate_route(%{__struct__: struct} = platform, route, options) do

--- a/lib/juvet/router/route_error.ex
+++ b/lib/juvet/router/route_error.ex
@@ -1,0 +1,18 @@
+defmodule Juvet.Router.RouteError do
+  @moduledoc """
+  Exception raised when an exception is found within a route..
+  """
+  defexception status: 404,
+               message: "invalid route",
+               router: nil
+
+  def exception(opts) do
+    message = Keyword.fetch!(opts, :message)
+    router = Keyword.fetch!(opts, :router)
+
+    %__MODULE__{
+      message: message,
+      router: router
+    }
+  end
+end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -37,6 +37,9 @@ defmodule Juvet.Router.SlackPlatform do
     if command_request?(request, command_text), do: route
   end
 
+  def validate(%{platform: %{platform: :slack}} = platform), do: {:ok, platform}
+  def validate(_platform), do: {:error, :unknown_platform}
+
   def validate_route(
         _platform,
         %Juvet.Router.Route{type: :action} = route,

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -56,7 +56,7 @@ defmodule Juvet.Router.SlackPlatform do
 
   defp action_request?(%{params: %{"payload" => payload}}, action_id) do
     payload = payload |> Poison.decode!()
-    action = payload["actions"] |> Poison.decode!() |> List.first()
+    action = payload["actions"] |> List.first()
 
     action["action_id"] == action_id
   end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -32,6 +32,13 @@ defmodule Juvet.Router.SlackPlatform do
 
   def validate_route(
         _platform,
+        %Juvet.Router.Route{type: :action} = route,
+        _options
+      ),
+      do: {:ok, route}
+
+  def validate_route(
+        _platform,
         %Juvet.Router.Route{type: :command} = route,
         _options
       ),

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -37,7 +37,7 @@ defmodule Juvet.Router.SlackPlatform do
     if command_request?(request, command_text), do: route
   end
 
-  def validate(%{platform: %{platform: :slack}} = platform), do: {:ok, platform}
+  def validate(%{platform: %{platform: :slack} = platform}), do: {:ok, platform}
   def validate(_platform), do: {:error, :unknown_platform}
 
   def validate_route(

--- a/lib/juvet/router/state.ex
+++ b/lib/juvet/router/state.ex
@@ -1,0 +1,63 @@
+defmodule Juvet.Router.State do
+  @moduledoc false
+
+  alias Juvet.Router.{Platform, RouteError}
+
+  @platforms :juvet_platforms
+
+  def init(module), do: put_platforms(module, [])
+
+  def get_platforms(module) do
+    Module.get_attribute(module, @platforms)
+  end
+
+  def pop_platform(module) do
+    {platform, platforms} = List.pop_at(get_platforms(module), 0)
+
+    put_platforms(module, platforms)
+
+    platform
+  end
+
+  def put_platform!(module, platform) when is_atom(platform) do
+    case Platform.new(platform) |> Platform.validate() do
+      {:ok, platform} ->
+        put_platform(module, platform)
+
+      {:error, :unknown_platform} ->
+        raise RouteError,
+          message: "Platform `#{platform}` is not valid.",
+          router: module
+    end
+  end
+
+  def put_platform(module, platform) do
+    platforms = get_platforms(module)
+
+    platforms = [platform | platforms]
+
+    put_platforms(module, platforms)
+  end
+
+  def put_route_on_top!(module, route) do
+    platform = pop_platform(module)
+
+    case Platform.put_route(platform, route) do
+      {:ok, platform} ->
+        put_platform(module, platform)
+
+      {:error, {:unknown_platform, route_info}} ->
+        put_platform(module, platform)
+
+        platform = Keyword.fetch!(route_info, :platform)
+
+        raise RouteError,
+          message: "Platform `#{platform.platform.platform}` is not valid.",
+          router: module
+    end
+
+    route
+  end
+
+  defp put_platforms(module, platforms), do: Module.put_attribute(module, @platforms, platforms)
+end

--- a/lib/juvet/router/unknown_platform.ex
+++ b/lib/juvet/router/unknown_platform.ex
@@ -9,6 +9,8 @@ defmodule Juvet.Router.UnknownPlatform do
     %__MODULE__{platform: platform}
   end
 
+  def validate(_platform), do: {:error, :unknown_platform}
+
   def validate_route(platform, route, options \\ %{}) do
     {:error, {:unknown_platform, [platform: platform, route: route, options: options]}}
   end

--- a/lib/juvet/slack_action_route.ex
+++ b/lib/juvet/slack_action_route.ex
@@ -3,11 +3,13 @@ defmodule Juvet.SlackActionRoute do
   Plug to handle any action from Slack.
   """
 
+  alias Juvet.Router.Conn
+
   @doc false
   def init(opts), do: opts
 
   @doc """
   Handles web requests targeted for the Slack actions API endpoint.
   """
-  def call(conn, _opts), do: Juvet.Router.Conn.run(conn)
+  def call(conn, _opts), do: Conn.run(conn)
 end

--- a/lib/juvet/slack_action_route.ex
+++ b/lib/juvet/slack_action_route.ex
@@ -3,15 +3,11 @@ defmodule Juvet.SlackActionRoute do
   Plug to handle any action from Slack.
   """
 
-  import Plug.Conn
-
   @doc false
   def init(opts), do: opts
 
   @doc """
   Handles web requests targeted for the Slack actions API endpoint.
   """
-  def call(conn, _opts) do
-    send_resp(conn, 200, "")
-  end
+  def call(conn, _opts), do: Juvet.Router.Conn.run(conn)
 end

--- a/lib/juvet/slack_command_route.ex
+++ b/lib/juvet/slack_command_route.ex
@@ -3,49 +3,11 @@ defmodule Juvet.SlackCommandRoute do
   Plug to handle any command from Slack.
   """
 
-  import Plug.Conn
-
   @doc false
   def init(opts), do: opts
 
   @doc """
   Handles web requests targeted for the Slack commands API endpoint.
   """
-  def call(conn, _opts) do
-    config = get_config(conn)
-    context = get_context(conn)
-
-    case Juvet.Runner.run(conn, Map.merge(%{configuration: config}, context)) do
-      {:ok, context} ->
-        maybe_send_response(context)
-
-      {:error, error} ->
-        send_error(conn, error)
-    end
-  end
-
-  defp get_config(%Plug.Conn{} = conn),
-    do: get_config(Juvet.Router.Conn.get_private(conn))
-
-  defp get_config(%{options: options}) do
-    get_in(options, [:configuration]) || []
-  end
-
-  defp get_config(_), do: []
-
-  defp get_context(%Plug.Conn{} = conn),
-    do: get_context(Juvet.Router.Conn.get_private(conn))
-
-  defp get_context(%{options: options}) do
-    get_in(options, [:context]) || %{}
-  end
-
-  defp get_context(_), do: %{}
-
-  defp send_error(conn, _error), do: conn |> send_resp(200, "")
-
-  defp maybe_send_response(%{conn: %{state: :chunked} = conn}), do: conn
-  defp maybe_send_response(%{conn: %{state: :sent} = conn}), do: conn
-
-  defp maybe_send_response(%{conn: _conn} = context), do: Juvet.Router.Conn.send_resp(context)
+  def call(conn, _opts), do: Juvet.Router.Conn.run(conn)
 end

--- a/lib/juvet/slack_command_route.ex
+++ b/lib/juvet/slack_command_route.ex
@@ -3,11 +3,13 @@ defmodule Juvet.SlackCommandRoute do
   Plug to handle any command from Slack.
   """
 
+  alias Juvet.Router.Conn
+
   @doc false
   def init(opts), do: opts
 
   @doc """
   Handles web requests targeted for the Slack commands API endpoint.
   """
-  def call(conn, _opts), do: Juvet.Router.Conn.run(conn)
+  def call(conn, _opts), do: Conn.run(conn)
 end

--- a/test/juvet/integration/slack_block_action_test.exs
+++ b/test/juvet/integration/slack_block_action_test.exs
@@ -1,0 +1,65 @@
+defmodule Juvet.Integration.SlackBlockActionTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      action("test_action_id", to: "juvet.integration.slack_block_action_test.test#action")
+    end
+  end
+
+  defmodule TestController do
+    def action(%{pid: pid}) do
+      send(pid, :called_controller)
+    end
+  end
+
+  def fixture(:valid_slack_block_action) do
+    payload =
+      %{
+        "type" => "block_actions",
+        "actions" => "[{\"action_id\":\"test_action_id\"}]"
+      }
+      |> Poison.encode!()
+
+    [
+      {"token", "SLACK_TOKEN"},
+      {"payload", payload}
+    ]
+    |> Enum.into(%{})
+  end
+
+  describe "with a valid Slack block action" do
+    setup do
+      signing_secret = generate_slack_signing_secret()
+
+      [signing_secret: signing_secret]
+    end
+
+    test "is routed correctly", %{signing_secret: signing_secret} do
+      params = fixture(:valid_slack_block_action)
+
+      conn =
+        request!(
+          :post,
+          "/slack/actions",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      # Request was successful and will not continue in the request chain
+      assert conn.halted
+
+      assert_received :called_controller
+    end
+  end
+end

--- a/test/juvet/integration/slack_block_action_test.exs
+++ b/test/juvet/integration/slack_block_action_test.exs
@@ -21,7 +21,7 @@ defmodule Juvet.Integration.SlackBlockActionTest do
     payload =
       %{
         "type" => "block_actions",
-        "actions" => "[{\"action_id\":\"test_action_id\"}]"
+        "actions" => [%{"action_id" => "test_action_id"}]
       }
       |> Poison.encode!()
 

--- a/test/juvet/integration/slack_command_test.exs
+++ b/test/juvet/integration/slack_command_test.exs
@@ -27,8 +27,6 @@ defmodule Juvet.Integration.SlackCommandTest do
     |> Enum.into(%{})
   end
 
-  def routed_to(_conn, _route), do: false
-
   describe "with a valid Slack command" do
     setup do
       signing_secret = generate_slack_signing_secret()

--- a/test/juvet/integration/slack_command_test.exs
+++ b/test/juvet/integration/slack_command_test.exs
@@ -8,6 +8,7 @@ defmodule Juvet.Integration.SlackCommandTest do
 
     platform :slack do
       command("/test", to: "juvet.integration.slack_command_test.test#action")
+      action("test_id", to: "controller#action")
     end
   end
 

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -77,6 +77,21 @@ defmodule Juvet.Router.PlatformTest do
     end
   end
 
+  describe "validate/1" do
+    test "returns an ok tuple with the platform" do
+      platform = Platform.new(:slack)
+
+      assert {:ok, actual} = Platform.validate(platform)
+      assert actual.platform == platform
+    end
+
+    test "returns an error tuple if the platform is not valid" do
+      platform = Platform.new(:blah)
+
+      assert {:error, :unknown_platform} = Platform.validate(platform)
+    end
+  end
+
   describe "validate_route/3" do
     setup do
       platform = Platform.new(:slack)

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -80,15 +80,21 @@ defmodule Juvet.Router.PlatformTest do
   describe "validate_route/3" do
     setup do
       platform = Platform.new(:slack)
-      route = Route.new(:command, "/test", to: "controller#action")
 
-      [platform: platform, route: route]
+      [platform: platform]
     end
 
-    test "returns an ok tuple with the route when the route is valid to add", %{
-      platform: platform,
-      route: route
+    test "returns an ok tuple with the route when the command route is valid to add", %{
+      platform: platform
     } do
+      route = Route.new(:command, "/test", to: "controller#action")
+      assert {:ok, route} = Platform.validate_route(platform, route)
+    end
+
+    test "returns an ok tuple with the route when the action route is valid to add", %{
+      platform: platform
+    } do
+      route = Route.new(:action, "test_action", to: "controller#action")
       assert {:ok, route} = Platform.validate_route(platform, route)
     end
 

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -82,7 +82,7 @@ defmodule Juvet.Router.PlatformTest do
       platform = Platform.new(:slack)
 
       assert {:ok, actual} = Platform.validate(platform)
-      assert actual.platform == platform
+      assert actual == platform
     end
 
     test "returns an error tuple if the platform is not valid" do

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -7,6 +7,7 @@ defmodule Juvet.RouterTest do
     use Juvet.Router
 
     platform :slack do
+      action("test_action_id", to: "controller#action")
       command("/test", to: "controller#action")
     end
   end
@@ -46,8 +47,9 @@ defmodule Juvet.RouterTest do
     test "accumulates the routes within the router" do
       platforms = Juvet.Router.platforms(MyRouter)
 
-      assert Enum.count(List.first(platforms).routes) == 1
-      assert List.first(List.first(platforms).routes).route == "/test"
+      assert Enum.count(List.first(platforms).routes) == 2
+      assert List.first(List.first(platforms).routes).route == "test_action_id"
+      assert List.last(List.first(platforms).routes).route == "/test"
     end
   end
 


### PR DESCRIPTION
This PR adds the ability for a client application to add routes for a Slack `block_action` interactive request.

These requests are sent to the application when a user interacts with any interactive block in the messages. A payload is sent along with an `action_id` which is an identifier to identify the action the user interacted with. The application will route the request to the appropriate controller and action.

In addition, a bug was found when compiling the routes. Since I ever only tested with one route, when I added another one, I discovered the bug. Unquoting the block just returned the last route but it needed to add the routes to the current platform specified. I extracted the state into `Juvet.Router.State` and that fixed the bug as well. The key was removing `register_attribute` with `accumulate: true`. The `State` not just wraps working with a `put_attribute`.

Closes #55
