### PR TITLE
Conversations#members Slack API endpoint

### DIFF
--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -6,6 +6,27 @@ defmodule Juvet.SlackAPI.Conversations do
   alias Juvet.SlackAPI
 
   @doc """
+  Request to retrieve all the user ids for the users within a Conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    members:[
+      "USER1",
+      "USER2"
+    ]
+  } = Juvet.SlackAPI.Conversations.members(%{token: token, channel: "CHANNEL1"})
+  """
+
+  def members(options \\ %{}) do
+    SlackAPI.make_request("conversations.members", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Requests a new Conversation between the requestor and the users or channel specified.
 
   Returns a map of the Slack response.

--- a/test/fixtures/vcr_cassettes/conversations/members/invalid_auth.json
+++ b/test/fixtures/vcr_cassettes/conversations/members/invalid_auth.json
@@ -1,0 +1,50 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/json; charset=utf-8",
+        "Authorization": "***",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/conversations.members"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":false,\"error\":\"invalid_auth\"}",
+      "headers": {
+        "date": "Tue, 22 Mar 2022 21:03:09 GMT",
+        "server": "Apache",
+        "x-powered-by": "HHVM/4.153.0",
+        "access-control-allow-origin": "*",
+        "referrer-policy": "no-referrer",
+        "x-slack-backend": "r",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "expires": "Mon, 26 Jul 1997 05:00:00 GMT",
+        "cache-control": "private, no-cache, no-store, must-revalidate",
+        "pragma": "no-cache",
+        "x-robots-tag": "noindex,nofollow",
+        "x-xss-protection": "0",
+        "x-content-type-options": "nosniff",
+        "x-slack-req-id": "4666c0eb9c5be329ccbd6da8a22d92bb",
+        "vary": "Accept-Encoding",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "6",
+        "x-backend": "main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-kmxh",
+        "x-slack-shared-secret-outcome": "no-match",
+        "via": "envoy-www-iad-hj0w, envoy-edge-iad-24wx",
+        "x-edge-backend": "envoy-www",
+        "x-slack-edge-shared-secret-outcome": "no-match",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixtures/vcr_cassettes/conversations/members/successful.json
+++ b/test/fixtures/vcr_cassettes/conversations/members/successful.json
@@ -1,0 +1,51 @@
+[
+  {
+    "request": {
+      "body": "channel=C04ASG29V",
+      "headers": {
+        "Accept": "application/json; charset=utf-8",
+        "Authorization": "***",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:51345/api/conversations.members"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"ok\":true,\"members\":[\"U04ASG29K\",\"U052YB8KQ\",\"U053KUSLV\"],\"response_metadata\":{\"next_cursor\":\"\"}}",
+      "headers": {
+        "date": "Tue, 22 Mar 2022 21:03:08 GMT",
+        "server": "Apache",
+        "x-powered-by": "HHVM/4.153.0",
+        "access-control-allow-origin": "*",
+        "referrer-policy": "no-referrer",
+        "x-slack-backend": "r",
+        "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
+        "access-control-expose-headers": "x-slack-req-id, retry-after",
+        "x-oauth-scopes": "users:read,team:read,channels:manage,im:write,chat:write,chat:write.public,commands,channels:read,groups:read,mpim:read",
+        "x-accepted-oauth-scopes": "channels:read,groups:read,mpim:read,im:read,read",
+        "expires": "Mon, 26 Jul 1997 05:00:00 GMT",
+        "cache-control": "private, no-cache, no-store, must-revalidate",
+        "pragma": "no-cache",
+        "x-xss-protection": "0",
+        "x-content-type-options": "nosniff",
+        "x-slack-req-id": "d1676d912aaccfe9730c02c066b859d5",
+        "vary": "Accept-Encoding",
+        "content-type": "application/json; charset=utf-8",
+        "x-envoy-upstream-service-time": "28",
+        "x-backend": "main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow",
+        "x-server": "slack-www-hhvm-main-iad-n4le",
+        "x-slack-shared-secret-outcome": "no-match",
+        "via": "envoy-www-iad-abhh, envoy-edge-iad-24wx",
+        "x-edge-backend": "envoy-www",
+        "x-slack-edge-shared-secret-outcome": "no-match",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/juvet/slack_api/conversations_test.exs
+++ b/test/juvet/slack_api/conversations_test.exs
@@ -9,10 +9,32 @@ defmodule Juvet.SlackAPI.ConversationsTest do
   end
 
   setup do
-    {:ok, users: ["USER1"], token: "TOKEN"}
+    {:ok, channel: "CHANNEL1", users: ["USER1"], token: "TOKEN"}
   end
 
-  describe "SlackAPI.Conversations.open/1" do
+  describe "members/1" do
+    test "returns the users for the channel specified", %{channel: channel, token: token} do
+      use_cassette "conversations/members/successful" do
+        assert {:ok, response} = SlackAPI.Conversations.members(%{channel: channel, token: token})
+
+        assert Enum.count(response[:members]) > 0
+      end
+    end
+
+    test "returns an error from an unsuccessful API call", %{
+      channel: channel,
+      token: token
+    } do
+      use_cassette "conversations/members/invalid_auth" do
+        assert {:error, response} =
+                 SlackAPI.Conversations.members(%{channel: channel, token: token})
+
+        assert response[:error] == "invalid_auth"
+      end
+    end
+  end
+
+  describe "open/1" do
     test "returns the channel id", %{users: users, token: token} do
       use_cassette "conversations/open/successful" do
         assert {:ok, response} = SlackAPI.Conversations.open(%{users: users, token: token})


### PR DESCRIPTION
This PR adds the endpoint `conversations.members` to the Slack API list of supported endpoints.
