### PR TITLE
Views API Endpoints

### DIFF
--- a/lib/juvet/slack_api/views.ex
+++ b/lib/juvet/slack_api/views.ex
@@ -20,11 +20,20 @@ defmodule Juvet.SlackAPI.Views do
   } = Juvet.SlackAPI.Views.open(%{token: token, trigger_id: trigger_id, view: view})
   """
   def open(options \\ %{}) do
-    options = options |> transform_options
+    options = options |> transform_options |> IO.inspect(label: "options")
 
     SlackAPI.make_request("views.open", options)
     |> SlackAPI.render_response()
   end
 
-  defp transform_options(options), do: options
+  defp encode_view(nil), do: nil
+  defp encode_view(view), do: Poison.encode!(view)
+
+  defp transform_options(options) do
+    options
+    |> Map.get_and_update(:view, &{&1, encode_view(&1)})
+    |> elem(1)
+    |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
+    |> Enum.into(%{})
+  end
 end

--- a/lib/juvet/slack_api/views.ex
+++ b/lib/juvet/slack_api/views.ex
@@ -6,6 +6,27 @@ defmodule Juvet.SlackAPI.Views do
   alias Juvet.SlackAPI
 
   @doc """
+  Publish a static view for a User.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    view: {
+      id: "VIEW1"
+    }
+  } = Juvet.SlackAPI.Views.publish(%{token: token, user_id: user_id, view: view})
+  """
+  def publish(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("views.publish", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Opens a view for a user.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/views.ex
+++ b/lib/juvet/slack_api/views.ex
@@ -20,9 +20,30 @@ defmodule Juvet.SlackAPI.Views do
   } = Juvet.SlackAPI.Views.open(%{token: token, trigger_id: trigger_id, view: view})
   """
   def open(options \\ %{}) do
-    options = options |> transform_options |> IO.inspect(label: "options")
+    options = options |> transform_options
 
     SlackAPI.make_request("views.open", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
+  Update an existing view.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    view: {
+      id: "VIEW1"
+    }
+  } = Juvet.SlackAPI.Views.update(%{token: token, view_id: view_id, view: view})
+  """
+  def update(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("views.update", options)
     |> SlackAPI.render_response()
   end
 

--- a/lib/juvet/slack_api/views.ex
+++ b/lib/juvet/slack_api/views.ex
@@ -6,6 +6,27 @@ defmodule Juvet.SlackAPI.Views do
   alias Juvet.SlackAPI
 
   @doc """
+  Push a view onto the stack of a root view.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    view: {
+      id: "VIEW1"
+    }
+  } = Juvet.SlackAPI.Views.push(%{token: token, trigger_id: trigger_id, view: view})
+  """
+  def push(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("views.push", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Publish a static view for a User.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/views.ex
+++ b/lib/juvet/slack_api/views.ex
@@ -1,0 +1,30 @@
+defmodule Juvet.SlackAPI.Views do
+  @moduledoc """
+  A wrapper around the views methods on the Slack API.
+  """
+
+  alias Juvet.SlackAPI
+
+  @doc """
+  Opens a view for a user.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    view: {
+      id: "VIEW1"
+    }
+  } = Juvet.SlackAPI.Views.open(%{token: token, trigger_id: trigger_id, view: view})
+  """
+  def open(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("views.open", options)
+    |> SlackAPI.render_response()
+  end
+
+  defp transform_options(options), do: options
+end


### PR DESCRIPTION
This PR adds the [views methods](https://api.slack.com/methods?filter=views) to the `SlackAPI` module.

It adds the following methods:

* `SlackAPI.Views.open`

NOTE: This does not adds tests. It is too painful of a strategy. Thinking about how to make this easier.
