### PR TITLE
View Submission Route

### DIFF
--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -51,6 +51,15 @@ defmodule Juvet.Router do
     end
   end
 
+  defmacro view_submission(callback_id, options \\ []) do
+    quote do
+      Router.State.put_route_on_top!(
+        __MODULE__,
+        Route.new(:view_submission, unquote(callback_id), unquote(options))
+      )
+    end
+  end
+
   def exists?(mod) do
     Keyword.has_key?(mod.__info__(:functions), :__platforms__)
   rescue

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -71,9 +71,11 @@ defmodule Juvet.Router.SlackPlatform do
   def validate_route(platform, %Juvet.Router.Route{} = route, options),
     do: {:error, {:unknown_route, [platform: platform, route: route, options: options]}}
 
+  defp action_from_payload(%{"actions" => actions}), do: List.first(actions)
+  defp action_from_payload(_payload), do: nil
+
   defp action_request?(%{params: %{"payload" => payload}}, action_id) do
-    payload = payload |> Poison.decode!()
-    action = payload["actions"] |> List.first()
+    action = payload |> Poison.decode!() |> action_from_payload
 
     normalized_value(action["action_id"]) == normalized_value(action_id)
   end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -54,6 +54,13 @@ defmodule Juvet.Router.SlackPlatform do
       ),
       do: {:ok, route}
 
+  def validate_route(
+        _platform,
+        %Juvet.Router.Route{type: :view_submission} = route,
+        _options
+      ),
+      do: {:ok, route}
+
   def validate_route(platform, %Juvet.Router.Route{} = route, options),
     do: {:error, {:unknown_route, [platform: platform, route: route, options: options]}}
 

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -99,4 +99,6 @@ defmodule Juvet.Router.SlackPlatform do
 
     normalized_value(view["callback_id"]) == normalized_value(callback_id)
   end
+
+  defp view_submission_request?(_request, _callback_id), do: false
 end

--- a/lib/juvet/router/state.ex
+++ b/lib/juvet/router/state.ex
@@ -54,6 +54,17 @@ defmodule Juvet.Router.State do
         raise RouteError,
           message: "Platform `#{platform.platform.platform}` is not valid.",
           router: module
+
+      {:error, {:unknown_route, route_info}} ->
+        put_platform(module, platform)
+
+        platform = Keyword.fetch!(route_info, :platform)
+        route = Keyword.fetch!(route_info, :route)
+
+        raise RouteError,
+          message:
+            "Route `#{route.route}` (#{route.type}) for `#{platform.platform.platform}` not found.",
+          router: module
     end
 
     route

--- a/test/juvet/integration/slack_view_submission_test.exs
+++ b/test/juvet/integration/slack_view_submission_test.exs
@@ -1,0 +1,68 @@
+defmodule Juvet.Integration.SlackViewSubmissionTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      view_submission("submitted",
+        to: "juvet.integration.slack_view_submission_test.test#submit"
+      )
+    end
+  end
+
+  defmodule TestController do
+    def submit(%{pid: pid}) do
+      send(pid, :called_controller)
+    end
+  end
+
+  def fixture(:valid_slack_view_submission, callback_id \\ "CALLBACK") do
+    view =
+      [
+        {"callback_id", callback_id}
+      ]
+      |> Enum.into(%{})
+
+    [
+      {"type", "view_submission"},
+      {"token", "SLACK_TOKEN"},
+      {"team_id", "T1234"},
+      {"view", view |> Poison.encode!()}
+    ]
+    |> Enum.into(%{})
+  end
+
+  describe "with a valid Slack command" do
+    setup do
+      signing_secret = generate_slack_signing_secret()
+
+      [signing_secret: signing_secret]
+    end
+
+    test "is routed correctly", %{signing_secret: signing_secret} do
+      params = fixture(:valid_slack_view_submission, "submitted")
+
+      conn =
+        request!(
+          :post,
+          "/slack/actions",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      # Request was successful and will not continue in the request chain
+      assert conn.halted
+
+      assert_received :called_controller
+    end
+  end
+end

--- a/test/juvet/integration/slack_view_submission_test.exs
+++ b/test/juvet/integration/slack_view_submission_test.exs
@@ -26,11 +26,18 @@ defmodule Juvet.Integration.SlackViewSubmissionTest do
       ]
       |> Enum.into(%{})
 
+    payload =
+      [
+        {"type", "view_submission"},
+        {"token", "SLACK_TOKEN"},
+        {"team_id", "T1234"},
+        {"view", view}
+      ]
+      |> Enum.into(%{})
+      |> Poison.encode!()
+
     [
-      {"type", "view_submission"},
-      {"token", "SLACK_TOKEN"},
-      {"team_id", "T1234"},
-      {"view", view |> Poison.encode!()}
+      {"payload", payload}
     ]
     |> Enum.into(%{})
   end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -113,6 +113,13 @@ defmodule Juvet.Router.PlatformTest do
       assert {:ok, route} = Platform.validate_route(platform, route)
     end
 
+    test "returns an ok tuple with the route when the view submission route is valid to add", %{
+      platform: platform
+    } do
+      route = Route.new(:view_submission, "test_callback", to: "controller#action")
+      assert {:ok, route} = Platform.validate_route(platform, route)
+    end
+
     test "returns an error tuple with the route when the route is not valid", %{
       platform: platform
     } do

--- a/test/juvet/router_test.exs
+++ b/test/juvet/router_test.exs
@@ -9,6 +9,7 @@ defmodule Juvet.RouterTest do
     platform :slack do
       action("test_action_id", to: "controller#action")
       command("/test", to: "controller#action")
+      view_submission("test_callback_id", to: "controller#action")
     end
   end
 
@@ -47,9 +48,10 @@ defmodule Juvet.RouterTest do
     test "accumulates the routes within the router" do
       platforms = Juvet.Router.platforms(MyRouter)
 
-      assert Enum.count(List.first(platforms).routes) == 2
-      assert List.first(List.first(platforms).routes).route == "test_action_id"
-      assert List.last(List.first(platforms).routes).route == "/test"
+      assert Enum.count(List.first(platforms).routes) == 3
+      assert Enum.at(List.first(platforms).routes, 0).route == "test_action_id"
+      assert Enum.at(List.first(platforms).routes, 1).route == "/test"
+      assert Enum.at(List.first(platforms).routes, 2).route == "test_callback_id"
     end
   end
 


### PR DESCRIPTION
This PR adds the ability for a client application to add routes for a Slack `view_submission` interactive request.

These requests are sent to the same destination as `block_actions` endpoint and handled via Juvet. The view payload is sent along and the `callback_id` is checked to identify the request.
