### PR TITLE
Update Context via Controller

### DIFF
--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -17,6 +17,9 @@ defmodule Juvet.Controller do
         send_the_response(context)
       end
 
+      def update_response(context, %Response{} = response),
+        do: maybe_update_response(context, response)
+
       defp send_the_response(context) do
         conn = Conn.send_resp(context)
         Map.put(context, :conn, conn)

--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -3,19 +3,29 @@ defmodule Juvet.Controller do
   Helper functions for a module handling a request from a platform.
   """
 
-  alias Juvet.Router.Conn
+  alias Juvet.Router.{Conn, Response}
 
   defmacro __using__(_opts) do
     quote do
-      def send_response(context, response \\ nil) do
+      def send_response(context, response \\ nil)
+
+      def send_response(context, nil), do: send_the_response(context)
+
+      def send_response(context, %Response{} = response) do
         context = context |> maybe_update_response(response)
 
+        send_the_response(context)
+      end
+
+      defp send_the_response(context) do
         conn = Conn.send_resp(context)
         Map.put(context, :conn, conn)
       end
 
       defp maybe_update_response(context, nil), do: context
-      defp maybe_update_response(context, response), do: Map.put(context, :response, response)
+
+      defp maybe_update_response(context, %Response{} = response),
+        do: Map.put(context, :response, response)
     end
   end
 end

--- a/lib/juvet/middleware.ex
+++ b/lib/juvet/middleware.ex
@@ -12,7 +12,7 @@ defmodule Juvet.Middleware do
       {Juvet.Middleware.ParseRequest},
       {Juvet.Middleware.IdentifyRequest},
       {Juvet.Middleware.Slack.VerifyRequest},
-      {Juvet.Midddleware.BuildDefaultResponse},
+      {Juvet.Middleware.BuildDefaultResponse},
       {Juvet.Middleware.RouteRequest}
     ] ++ group(:partial)
   end

--- a/lib/juvet/middleware/action_runner.ex
+++ b/lib/juvet/middleware/action_runner.ex
@@ -9,12 +9,19 @@ defmodule Juvet.Middleware.ActionRunner do
     f = elem(action, 1)
 
     try do
-      apply(m, f, [context])
+      case apply(m, f, [context]) do
+        {:ok, ctx} when is_map(ctx) ->
+          {:ok, ctx}
+
+        {:error, error} ->
+          {:error, error}
+
+        _ ->
+          {:error,
+           "`#{f}/1` is required to return the `context` in an `:ok` tuple or an `:error` tuple"}
+      end
     rescue
       UndefinedFunctionError -> {:error, "`#{m}.#{f}/1` is not defined"}
-    else
-      _ ->
-        {:ok, context}
     end
   end
 

--- a/lib/juvet/middleware/build_default_response.ex
+++ b/lib/juvet/middleware/build_default_response.ex
@@ -1,4 +1,4 @@
-defmodule Juvet.Midddleware.BuildDefaultResponse do
+defmodule Juvet.Middleware.BuildDefaultResponse do
   @moduledoc """
   Middleware to create a default `Juvet.Router.Response` for the request that is
   contained within the context.

--- a/test/juvet/controller_test.exs
+++ b/test/juvet/controller_test.exs
@@ -10,6 +10,28 @@ defmodule Juvet.ControllerTest do
     def send_response_test(context, response \\ nil) do
       send_response(context, response)
     end
+
+    def update_response_test(context, response) do
+      update_response(context, response)
+    end
+  end
+
+  describe "update_response/2" do
+    setup do
+      context = %{
+        conn: build_conn(:post, "/slack/commands"),
+        response: Response.new(body: "old")
+      }
+
+      [context: context]
+    end
+
+    test "updates the response in the context", %{context: context} do
+      %{response: response} =
+        MyController.update_response_test(context, Response.new(body: "new"))
+
+      assert response.body == "new"
+    end
   end
 
   describe "send_response/2" do

--- a/test/juvet/integration/slack_block_action_test.exs
+++ b/test/juvet/integration/slack_block_action_test.exs
@@ -12,8 +12,10 @@ defmodule Juvet.Integration.SlackBlockActionTest do
   end
 
   defmodule TestController do
-    def action(%{pid: pid}) do
+    def action(%{pid: pid} = context) do
       send(pid, :called_controller)
+
+      {:ok, context}
     end
   end
 

--- a/test/juvet/integration/slack_command_test.exs
+++ b/test/juvet/integration/slack_command_test.exs
@@ -13,8 +13,10 @@ defmodule Juvet.Integration.SlackCommandTest do
   end
 
   defmodule TestController do
-    def action(%{pid: pid}) do
+    def action(%{pid: pid} = context) do
       send(pid, :called_controller)
+
+      {:ok, context}
     end
   end
 

--- a/test/juvet/integration/slack_view_submission_test.exs
+++ b/test/juvet/integration/slack_view_submission_test.exs
@@ -14,8 +14,10 @@ defmodule Juvet.Integration.SlackViewSubmissionTest do
   end
 
   defmodule TestController do
-    def submit(%{pid: pid}) do
+    def submit(%{pid: pid} = context) do
       send(pid, :called_controller)
+
+      {:ok, context}
     end
   end
 

--- a/test/juvet/middleware/build_default_response_test.exs
+++ b/test/juvet/middleware/build_default_response_test.exs
@@ -1,7 +1,7 @@
-defmodule Juvet.Midddleware.BuildDefaultResponseTest do
+defmodule Juvet.Middleware.BuildDefaultResponseTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Midddleware.BuildDefaultResponse
+  alias Juvet.Middleware.BuildDefaultResponse
   alias Juvet.Router.Request
 
   describe "call/1" do

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -12,12 +12,13 @@ defmodule Juvet.RunnerTest do
   end
 
   defmodule TestController do
-    def action(%{pid: pid}) do
+    def action(%{pid: pid} = context) do
       send(pid, :called_controller)
+
+      {:ok, context}
     end
 
-    def action(_context) do
-    end
+    def action(context), do: {:ok, context}
   end
 
   describe "route/2" do


### PR DESCRIPTION
This PR adds a breaking change where controller has to return an `{:ok, context}` or an `{:error, error}` tuple from every controller action.

This will allow the client to update the response that get's sent, and generally update the context within a controller action.
