### PR TITLE
Refactor Routing

### DIFF
--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -73,4 +73,10 @@ defmodule Juvet.Router do
   def platforms(router) do
     router.__platforms__()
   end
+
+  # Behaviour
+  @callback new(atom()) :: struct()
+
+  @callback validate(Juvet.Router.Platform.t()) ::
+              {:ok, Juvet.Router.Platform.t()} | {:error, term()}
 end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -77,7 +77,7 @@ defmodule Juvet.Router do
   # Behaviour
   @callback new(atom()) :: struct()
 
-  @callback find_route(Juvet.Router.Platform.t(), Juvet.Router.Request.t()) ::
+  @callback find_route(%{platform: Juvet.Router.Platform.t()}, Juvet.Router.Request.t()) ::
               {:ok, Juvet.Router.Route.t()} | {:error, term()}
 
   @callback validate(Juvet.Router.Platform.t()) ::

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -77,6 +77,9 @@ defmodule Juvet.Router do
   # Behaviour
   @callback new(atom()) :: struct()
 
+  @callback find_route(Juvet.Router.Platform.t(), Juvet.Router.Request.t()) ::
+              {:ok, Juvet.Router.Route.t()} | {:error, term()}
+
   @callback validate(Juvet.Router.Platform.t()) ::
               {:ok, Juvet.Router.Platform.t()} | {:error, term()}
 

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -79,4 +79,7 @@ defmodule Juvet.Router do
 
   @callback validate(Juvet.Router.Platform.t()) ::
               {:ok, Juvet.Router.Platform.t()} | {:error, term()}
+
+  @callback validate_route(%{platform: Juvet.Router.Platform.t()}, Juvet.Router.Route.t(), map()) ::
+              {:ok, Juvet.Router.Route.t()} | {:error, term()}
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -9,14 +9,14 @@ defmodule Juvet.Router.Platform do
         }
   defstruct platform: nil, routes: []
 
-  alias Juvet.Router.PlatformFactory
+  alias Juvet.Router.RouterFactory
 
   def new(platform) do
     %__MODULE__{platform: platform}
   end
 
   def put_route(%Juvet.Router.Platform{} = platform, route, options \\ %{}) do
-    case PlatformFactory.validate_route(platform, route, options) do
+    case RouterFactory.validate_route(platform, route, options) do
       {:ok, route} ->
         routes = platform.routes
         {:ok, %{platform | routes: routes ++ [route]}}
@@ -27,5 +27,5 @@ defmodule Juvet.Router.Platform do
   end
 
   def validate(%Juvet.Router.Platform{} = platform),
-    do: PlatformFactory.router(platform).validate(platform)
+    do: RouterFactory.router(platform).validate(platform)
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -15,8 +15,8 @@ defmodule Juvet.Router.Platform do
     %__MODULE__{platform: platform}
   end
 
-  def put_route(platform, route, options \\ %{}) do
-    case validate_route(platform, route, options) do
+  def put_route(%Juvet.Router.Platform{} = platform, route, options \\ %{}) do
+    case PlatformFactory.validate_route(platform, route, options) do
       {:ok, route} ->
         routes = platform.routes
         {:ok, %{platform | routes: routes ++ [route]}}
@@ -26,12 +26,6 @@ defmodule Juvet.Router.Platform do
     end
   end
 
-  def validate(platform) do
-    PlatformFactory.new(platform) |> PlatformFactory.validate()
-  end
-
-  def validate_route(platform, route, options \\ %{}) do
-    PlatformFactory.new(platform)
-    |> PlatformFactory.validate_route(route, options)
-  end
+  def validate(%Juvet.Router.Platform{} = platform),
+    do: PlatformFactory.router(platform).validate(platform)
 end

--- a/lib/juvet/router/platform.ex
+++ b/lib/juvet/router/platform.ex
@@ -3,6 +3,10 @@ defmodule Juvet.Router.Platform do
   Represents a list of routes for a specific platform (e.g. `Slack`).
   """
 
+  @type t :: %__MODULE__{
+          platform: atom() | nil,
+          routes: list(Juvet.Router.Route.t())
+        }
   defstruct platform: nil, routes: []
 
   alias Juvet.Router.PlatformFactory
@@ -20,10 +24,6 @@ defmodule Juvet.Router.Platform do
       {:error, error} ->
         {:error, error}
     end
-  end
-
-  def find_route(platform, request) do
-    PlatformFactory.new(platform) |> PlatformFactory.find_route(request)
   end
 
   def validate(platform) do

--- a/lib/juvet/router/platform_factory.ex
+++ b/lib/juvet/router/platform_factory.ex
@@ -8,24 +8,13 @@ defmodule Juvet.Router.PlatformFactory do
   def new(:unknown, platform), do: UnknownPlatform.new(platform)
 
   def new(platform) do
-    mod =
-      String.to_existing_atom(
-        "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform.platform))}Platform"
-      )
-
-    mod.new(platform)
+    platform_module(platform).new(platform)
   rescue
     _ in ArgumentError -> new(:unknown, platform)
   end
 
-  def find_route(platform, request)
-
-  def find_route(%{__struct__: struct} = platform, request) do
-    platform |> struct.find_route(request)
-  end
-
-  def find_route(platform, request) do
-    platform |> platform.find_route(request)
+  def find_route(%Juvet.Router.Platform{} = platform, request) do
+    platform_module(platform).find_route(new(platform), request)
   end
 
   def validate(%{__struct__: struct} = platform), do: struct.validate(platform)
@@ -39,4 +28,10 @@ defmodule Juvet.Router.PlatformFactory do
   def validate_route(platform, route, options) do
     platform |> platform.validate_route(route, options)
   end
+
+  defp platform_module(%Juvet.Router.Platform{platform: platform}),
+    do:
+      String.to_existing_atom(
+        "Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform"
+      )
 end

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -3,6 +3,7 @@ defmodule Juvet.Router.Request do
   Represents a single request from a platform.
   """
 
+  @type t :: %__MODULE__{}
   defstruct [
     :host,
     :method,

--- a/lib/juvet/router/route.ex
+++ b/lib/juvet/router/route.ex
@@ -3,6 +3,11 @@ defmodule Juvet.Router.Route do
   Represents a single route that is defined within the `Juvet.Router`.
   """
 
+  @type t :: %__MODULE__{
+          type: atom(),
+          route: String.t(),
+          options: keyword()
+        }
   defstruct type: nil, route: nil, options: []
 
   def new(type, route, options \\ []) do

--- a/lib/juvet/router/route_finder.ex
+++ b/lib/juvet/router/route_finder.ex
@@ -3,8 +3,10 @@ defmodule Juvet.Router.RouteFinder do
   Finds a specific `Juvet.Router.Route` based on a `Juvet.Router.Request`.
   """
 
-  alias Juvet.Router.Platform
+  alias Juvet.Router.PlatformFactory
 
+  @spec find(list(Juvet.Router.Platform.t()), Juvet.Router.Request.t()) ::
+          {:ok, Juvet.Router.Route.t()} | {:error, any()}
   def find(platforms, request) do
     route =
       Enum.map(platforms, fn platform ->
@@ -21,7 +23,7 @@ defmodule Juvet.Router.RouteFinder do
     end
   end
 
-  def find_route(platform, request) do
-    Platform.find_route(platform, request)
-  end
+  @spec find_route(Juvet.Router.Platform.t(), Juvet.Router.Request.t()) ::
+          {:ok, Juvet.Router.Route.t()} | {:error, any()}
+  def find_route(platform, request), do: PlatformFactory.find_route(platform, request)
 end

--- a/lib/juvet/router/route_finder.ex
+++ b/lib/juvet/router/route_finder.ex
@@ -3,7 +3,7 @@ defmodule Juvet.Router.RouteFinder do
   Finds a specific `Juvet.Router.Route` based on a `Juvet.Router.Request`.
   """
 
-  alias Juvet.Router.PlatformFactory
+  alias Juvet.Router.RouterFactory
 
   @spec find(list(Juvet.Router.Platform.t()), Juvet.Router.Request.t()) ::
           {:ok, Juvet.Router.Route.t()} | {:error, any()}
@@ -25,5 +25,5 @@ defmodule Juvet.Router.RouteFinder do
 
   @spec find_route(Juvet.Router.Platform.t(), Juvet.Router.Request.t()) ::
           {:ok, Juvet.Router.Route.t()} | {:error, any()}
-  def find_route(platform, request), do: PlatformFactory.find_route(platform, request)
+  def find_route(platform, request), do: RouterFactory.find_route(platform, request)
 end

--- a/lib/juvet/router/router_factory.ex
+++ b/lib/juvet/router/router_factory.ex
@@ -1,17 +1,14 @@
-defmodule Juvet.Router.PlatformFactory do
+defmodule Juvet.Router.RouterFactory do
   @moduledoc """
-  Module to create a `Juvet.Router.Platform` based on the Atom that is passed in.
+  Module to create a `Juvet.Router` based on the `Juvet.Router.Platform` that is passed in.
   """
 
   alias Juvet.Router.UnknownPlatform
 
-  def new(platform), do: router(platform).new(platform)
-
   def find_route(%Juvet.Router.Platform{} = platform, request) do
-    router(platform).find_route(new(platform), request)
+    router(platform).find_route(to_router(platform), request)
   end
 
-  # TODO: This name will make sense in a bit
   def router(%Juvet.Router.Platform{platform: platform}) do
     String.to_existing_atom("Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform")
   rescue
@@ -19,6 +16,8 @@ defmodule Juvet.Router.PlatformFactory do
   end
 
   def validate_route(%Juvet.Router.Platform{} = platform, route, options \\ %{}) do
-    router(platform).validate_route(new(platform), route, options)
+    router(platform).validate_route(to_router(platform), route, options)
   end
+
+  defp to_router(%Juvet.Router.Platform{} = platform), do: router(platform).new(platform)
 end

--- a/lib/juvet/router/router_factory.ex
+++ b/lib/juvet/router/router_factory.ex
@@ -3,7 +3,7 @@ defmodule Juvet.Router.RouterFactory do
   Module to create a `Juvet.Router` based on the `Juvet.Router.Platform` that is passed in.
   """
 
-  alias Juvet.Router.UnknownPlatform
+  alias Juvet.Router.UnknownRouter
 
   def find_route(%Juvet.Router.Platform{} = platform, request) do
     router(platform).find_route(to_router(platform), request)
@@ -12,7 +12,7 @@ defmodule Juvet.Router.RouterFactory do
   def router(%Juvet.Router.Platform{platform: platform}) do
     String.to_existing_atom("Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform")
   rescue
-    _ in ArgumentError -> UnknownPlatform
+    _ in ArgumentError -> UnknownRouter
   end
 
   def validate_route(%Juvet.Router.Platform{} = platform, route, options \\ %{}) do

--- a/lib/juvet/router/router_factory.ex
+++ b/lib/juvet/router/router_factory.ex
@@ -10,7 +10,7 @@ defmodule Juvet.Router.RouterFactory do
   end
 
   def router(%Juvet.Router.Platform{platform: platform}) do
-    String.to_existing_atom("Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Platform")
+    String.to_existing_atom("Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Router")
   rescue
     _ in ArgumentError -> UnknownRouter
   end

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -7,6 +7,8 @@ defmodule Juvet.Router.SlackPlatform do
   """
 
   # name instead? to remove the platform.name
+  # platform_definition? instead
+  # Use Router instead of Platform, which means PlatformFactory == RouterFactory
   defstruct platform: nil
 
   def new(platform) do
@@ -47,7 +49,7 @@ defmodule Juvet.Router.SlackPlatform do
     if view_submission_request?(request, callback_id), do: route
   end
 
-  def validate(%{platform: %{platform: :slack} = platform}), do: {:ok, platform}
+  def validate(%{platform: :slack} = platform), do: {:ok, platform}
   def validate(_platform), do: {:error, :unknown_platform}
 
   def validate_route(

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -1,9 +1,12 @@
+# Juvet.Router.SlackRouter
+# @behavior Juvet.Router.PlatformRouter
 defmodule Juvet.Router.SlackPlatform do
   @moduledoc """
   Struct that represents the `Juvet.Router.Route`s that are available for the
   Slack platform.
   """
 
+  # name instead? to remove the platform.name
   defstruct platform: nil
 
   def new(platform) do

--- a/lib/juvet/router/slack_platform.ex
+++ b/lib/juvet/router/slack_platform.ex
@@ -1,5 +1,4 @@
 # Juvet.Router.SlackRouter
-# @behavior Juvet.Router.PlatformRouter
 defmodule Juvet.Router.SlackPlatform do
   @moduledoc """
   Struct that represents the `Juvet.Router.Route`s that are available for the

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -55,29 +55,33 @@ defmodule Juvet.Router.SlackRouter do
   @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
+  @impl Juvet.Router
   def validate_route(
-        _platform,
+        _router,
         %Juvet.Router.Route{type: :action} = route,
         _options
       ),
       do: {:ok, route}
 
+  @impl Juvet.Router
   def validate_route(
-        _platform,
+        _router,
         %Juvet.Router.Route{type: :command} = route,
         _options
       ),
       do: {:ok, route}
 
+  @impl Juvet.Router
   def validate_route(
-        _platform,
+        _router,
         %Juvet.Router.Route{type: :view_submission} = route,
         _options
       ),
       do: {:ok, route}
 
-  def validate_route(platform, %Juvet.Router.Route{} = route, options),
-    do: {:error, {:unknown_route, [platform: platform, route: route, options: options]}}
+  @impl Juvet.Router
+  def validate_route(router, %Juvet.Router.Route{} = route, options),
+    do: {:error, {:unknown_route, [router: router, route: route, options: options]}}
 
   defp action_from_payload(%{"actions" => actions}), do: List.first(actions)
   defp action_from_payload(_payload), do: %{}

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -16,16 +16,16 @@ defmodule Juvet.Router.SlackRouter do
   end
 
   @impl Juvet.Router
-  def find_route(platform, %{verified?: false} = request),
-    do: {:error, {:unverified_route, [platform: platform, request: request]}}
+  def find_route(router, %{verified?: false} = request),
+    do: {:error, {:unverified_route, [router: router, request: request]}}
 
   @impl Juvet.Router
   def find_route(
-        %{platform: %{routes: routes}} = platform,
+        %{platform: %{routes: routes}} = router,
         %{platform: :slack, verified?: true} = request
       ) do
     case Enum.find(routes, &(!is_nil(find_route(&1, request)))) do
-      nil -> {:error, {:unknown_route, [platform: platform, request: request]}}
+      nil -> {:error, {:unknown_route, [router: router, request: request]}}
       route -> {:ok, route}
     end
   end

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -3,11 +3,14 @@ defmodule Juvet.Router.SlackRouter do
   Represents a `Juvet.Router` that is used for any routes defined under a Slack `Platform`.
   """
 
+  @behaviour Juvet.Router
+
   @type t :: %__MODULE__{
           platform: Juvet.Router.Platform.t()
         }
   defstruct platform: nil
 
+  @impl Juvet.Router
   def new(platform) do
     %__MODULE__{platform: platform}
   end
@@ -46,7 +49,10 @@ defmodule Juvet.Router.SlackRouter do
     if view_submission_request?(request, callback_id), do: route
   end
 
+  @impl Juvet.Router
   def validate(%{platform: :slack} = platform), do: {:ok, platform}
+
+  @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
   def validate_route(

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -1,13 +1,11 @@
-# Juvet.Router.SlackRouter
-defmodule Juvet.Router.SlackPlatform do
+defmodule Juvet.Router.SlackRouter do
   @moduledoc """
-  Struct that represents the `Juvet.Router.Route`s that are available for the
-  Slack platform.
+  Represents a `Juvet.Router` that is used for any routes defined under a Slack `Platform`.
   """
 
-  # name instead? to remove the platform.name
-  # platform_definition? instead
-  # Use Router instead of Platform, which means PlatformFactory == RouterFactory
+  @type t :: %__MODULE__{
+          platform: Juvet.Router.Platform.t()
+        }
   defstruct platform: nil
 
   def new(platform) do

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -15,9 +15,11 @@ defmodule Juvet.Router.SlackRouter do
     %__MODULE__{platform: platform}
   end
 
+  @impl Juvet.Router
   def find_route(platform, %{verified?: false} = request),
     do: {:error, {:unverified_route, [platform: platform, request: request]}}
 
+  @impl Juvet.Router
   def find_route(
         %{platform: %{routes: routes}} = platform,
         %{platform: :slack, verified?: true} = request

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -16,6 +16,10 @@ defmodule Juvet.Router.UnknownRouter do
   end
 
   @impl Juvet.Router
+  def find_route(platform, request),
+    do: {:error, {:unknown_route, [platform: platform, request: request]}}
+
+  @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
   @impl Juvet.Router

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -3,15 +3,19 @@ defmodule Juvet.Router.UnknownRouter do
   Represents a `Juvet.Router` that could not be idenfied for a platform definition.
   """
 
+  @behaviour Juvet.Router
+
   @type t :: %__MODULE__{
           platform: Juvet.Router.Platform.t()
         }
   defstruct platform: nil
 
+  @impl Juvet.Router
   def new(platform) do
     %__MODULE__{platform: platform}
   end
 
+  @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
   def validate_route(router, route, options \\ %{}) do

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -18,6 +18,7 @@ defmodule Juvet.Router.UnknownRouter do
   @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
+  @impl Juvet.Router
   def validate_route(router, route, options \\ %{}) do
     {:error, {:unknown_platform, [router: router, route: route, options: options]}}
   end

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -3,7 +3,10 @@ defmodule Juvet.Router.UnknownRouter do
   Represents a `Juvet.Router` that could not be idenfied for a platform definition.
   """
 
-  defstruct platform: :unknown
+  @type t :: %__MODULE__{
+          platform: Juvet.Router.Platform.t()
+        }
+  defstruct platform: nil
 
   def new(platform) do
     %__MODULE__{platform: platform}
@@ -11,7 +14,7 @@ defmodule Juvet.Router.UnknownRouter do
 
   def validate(_platform), do: {:error, :unknown_platform}
 
-  def validate_route(platform, route, options \\ %{}) do
-    {:error, {:unknown_platform, [platform: platform, route: route, options: options]}}
+  def validate_route(router, route, options \\ %{}) do
+    {:error, {:unknown_platform, [router: router, route: route, options: options]}}
   end
 end

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -1,9 +1,9 @@
-defmodule Juvet.Router.UnknownPlatform do
+defmodule Juvet.Router.UnknownRouter do
   @moduledoc """
-  Represents a `Juvet.Router.Platform` that could not be idenfied.
+  Represents a `Juvet.Router` that could not be idenfied for a platform definition.
   """
 
-  defstruct platform: nil
+  defstruct platform: :unknown
 
   def new(platform) do
     %__MODULE__{platform: platform}

--- a/test/juvet/router/platform_factory_test.exs
+++ b/test/juvet/router/platform_factory_test.exs
@@ -66,26 +66,47 @@ defmodule Juvet.Router.PlatformFactoryTest do
       route = Route.new(:command, "/test", to: "controller#action")
       platform = Platform.new(:slack)
 
-      [platform: %SlackPlatform{platform: platform}, route: route]
+      [platform: platform, route: route]
     end
 
-    test "delegates to the platform module", %{platform: platform, route: route} do
-      assert {:ok, route} ==
-               PlatformFactory.validate_route(platform, route)
+    test "returns an ok tuple with the route when the command route is valid to add", %{
+      platform: platform
+    } do
+      route = Route.new(:command, "/test", to: "controller#action")
+      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
     end
 
-    test "returns an error if the route is not valid", %{platform: platform} do
+    test "returns an ok tuple with the route when the action route is valid to add", %{
+      platform: platform
+    } do
+      route = Route.new(:action, "test_action", to: "controller#action")
+      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
+    end
+
+    test "returns an ok tuple with the route when the view submission route is valid to add", %{
+      platform: platform
+    } do
+      route = Route.new(:view_submission, "test_callback", to: "controller#action")
+      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
+    end
+
+    test "returns an error tuple with the route when the route is not valid", %{
+      platform: platform
+    } do
       error_route = %Route{type: :blah}
 
-      assert {:error, {:unknown_route, [platform: platform, route: error_route, options: %{}]}} =
-               PlatformFactory.validate_route(
-                 platform,
-                 error_route
-               )
+      assert {:error,
+              {:unknown_route,
+               [
+                 platform: %SlackPlatform{platform: %Platform{platform: :slack}},
+                 route: error_route,
+                 options: %{}
+               ]}} ==
+               PlatformFactory.validate_route(platform, error_route)
     end
 
     test "returns an error if the platform is not valid", %{route: route} do
-      unknown_platform = %UnknownPlatform{platform: :blah}
+      unknown_platform = Platform.new(:blah)
 
       assert {:error,
               {:unknown_platform, [platform: unknown_platform, route: route, options: %{}]}} =

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.Router.PlatformTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, Route, SlackPlatform}
+  alias Juvet.Router.{Platform, Route, SlackRouter}
 
   describe "put_route/3" do
     setup do
@@ -28,7 +28,7 @@ defmodule Juvet.Router.PlatformTest do
       assert error ==
                {:unknown_route,
                 [
-                  platform: %SlackPlatform{platform: platform},
+                  platform: %SlackRouter{platform: platform},
                   route: error_route,
                   options: %{}
                 ]}

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -49,48 +49,4 @@ defmodule Juvet.Router.PlatformTest do
       assert {:error, :unknown_platform} = Platform.validate(platform)
     end
   end
-
-  describe "validate_route/3" do
-    setup do
-      platform = Platform.new(:slack)
-
-      [platform: platform]
-    end
-
-    test "returns an ok tuple with the route when the command route is valid to add", %{
-      platform: platform
-    } do
-      route = Route.new(:command, "/test", to: "controller#action")
-      assert {:ok, route} = Platform.validate_route(platform, route)
-    end
-
-    test "returns an ok tuple with the route when the action route is valid to add", %{
-      platform: platform
-    } do
-      route = Route.new(:action, "test_action", to: "controller#action")
-      assert {:ok, route} = Platform.validate_route(platform, route)
-    end
-
-    test "returns an ok tuple with the route when the view submission route is valid to add", %{
-      platform: platform
-    } do
-      route = Route.new(:view_submission, "test_callback", to: "controller#action")
-      assert {:ok, route} = Platform.validate_route(platform, route)
-    end
-
-    test "returns an error tuple with the route when the route is not valid", %{
-      platform: platform
-    } do
-      error_route = %Route{type: :blah}
-
-      assert {:error,
-              {:unknown_route,
-               [
-                 platform: %SlackPlatform{platform: platform},
-                 route: error_route,
-                 options: %{}
-               ]}} ==
-               Platform.validate_route(platform, error_route)
-    end
-  end
 end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.Router.PlatformTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, Request, Route, SlackPlatform}
+  alias Juvet.Router.{Platform, Route, SlackPlatform}
 
   describe "put_route/3" do
     setup do
@@ -31,48 +31,6 @@ defmodule Juvet.Router.PlatformTest do
                   platform: %SlackPlatform{platform: platform},
                   route: error_route,
                   options: %{}
-                ]}
-    end
-  end
-
-  describe "find_route/2" do
-    setup do
-      platform = Platform.new(:slack)
-      route = Route.new(:command, "/test", to: "controller#action")
-      {:ok, platform} = Platform.put_route(platform, route)
-
-      request = Request.new(%{params: %{"command" => "test"}})
-      request = %{request | platform: :slack, verified?: true}
-
-      [platform: platform, request: request]
-    end
-
-    test "returns an ok tuple with the route that were found", %{
-      platform: platform,
-      request: request
-    } do
-      assert {:ok, route} = Platform.find_route(platform, request)
-      assert route.type == :command
-      assert route.route == "/test"
-      assert route.options == [to: "controller#action"]
-    end
-
-    test "returns an error tuple with the route when the route is not found", %{
-      platform: platform,
-      request: request
-    } do
-      request = %{
-        request
-        | params: Map.merge(request.params, %{"command" => "/blah"})
-      }
-
-      assert {:error, error} = Platform.find_route(platform, request)
-
-      assert error ==
-               {:unknown_route,
-                [
-                  platform: %SlackPlatform{platform: platform},
-                  request: request
                 ]}
     end
   end

--- a/test/juvet/router/platform_test.exs
+++ b/test/juvet/router/platform_test.exs
@@ -28,7 +28,7 @@ defmodule Juvet.Router.PlatformTest do
       assert error ==
                {:unknown_route,
                 [
-                  platform: %SlackRouter{platform: platform},
+                  router: %SlackRouter{platform: platform},
                   route: error_route,
                   options: %{}
                 ]}

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.Router.RouterFactoryTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, RouterFactory, Request, Route, SlackRouter, UnknownRouter}
+  alias Juvet.Router.{Platform, Request, Route, RouterFactory, SlackRouter, UnknownRouter}
 
   describe "find_route/2" do
     setup do

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -1,7 +1,7 @@
 defmodule Juvet.Router.RouterFactoryTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, RouterFactory, Request, Route, SlackPlatform}
+  alias Juvet.Router.{Platform, RouterFactory, Request, Route, SlackRouter, UnknownRouter}
 
   describe "find_route/2" do
     setup do
@@ -39,7 +39,7 @@ defmodule Juvet.Router.RouterFactoryTest do
       assert error ==
                {:unknown_route,
                 [
-                  platform: %SlackPlatform{platform: platform},
+                  platform: %SlackRouter{platform: platform},
                   request: request
                 ]}
     end
@@ -82,7 +82,7 @@ defmodule Juvet.Router.RouterFactoryTest do
       assert {:error,
               {:unknown_route,
                [
-                 platform: %SlackPlatform{platform: %Platform{platform: :slack}},
+                 platform: %SlackRouter{platform: %Platform{platform: :slack}},
                  route: error_route,
                  options: %{}
                ]}} ==
@@ -93,7 +93,8 @@ defmodule Juvet.Router.RouterFactoryTest do
       unknown_platform = Platform.new(:blah)
 
       assert {:error,
-              {:unknown_platform, [platform: unknown_platform, route: route, options: %{}]}} =
+              {:unknown_platform,
+               [router: %UnknownRouter{platform: unknown_platform}, route: route, options: %{}]}} =
                RouterFactory.validate_route(
                  unknown_platform,
                  route

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -39,7 +39,7 @@ defmodule Juvet.Router.RouterFactoryTest do
       assert error ==
                {:unknown_route,
                 [
-                  platform: %SlackRouter{platform: platform},
+                  router: %SlackRouter{platform: platform},
                   request: request
                 ]}
     end

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -1,23 +1,7 @@
-defmodule Juvet.Router.PlatformFactoryTest do
+defmodule Juvet.Router.RouterFactoryTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, PlatformFactory, Request, Route, SlackPlatform, UnknownPlatform}
-
-  describe "new/1" do
-    test "returns a SlackPlatform when the platform is slack" do
-      platform = Platform.new(:slack)
-
-      assert %SlackPlatform{platform: platform} ==
-               PlatformFactory.new(platform)
-    end
-
-    test "returns an UnknownFactory when the platform is not recognized" do
-      platform = Platform.new(:blah)
-
-      assert %UnknownPlatform{platform: platform} ==
-               PlatformFactory.new(platform)
-    end
-  end
+  alias Juvet.Router.{Platform, RouterFactory, Request, Route, SlackPlatform}
 
   describe "find_route/2" do
     setup do
@@ -35,7 +19,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
       platform: platform,
       request: request
     } do
-      assert {:ok, route} = PlatformFactory.find_route(platform, request)
+      assert {:ok, route} = RouterFactory.find_route(platform, request)
       assert route.type == :command
       assert route.route == "/test"
       assert route.options == [to: "controller#action"]
@@ -50,7 +34,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
         | params: Map.merge(request.params, %{"command" => "/blah"})
       }
 
-      assert {:error, error} = PlatformFactory.find_route(platform, request)
+      assert {:error, error} = RouterFactory.find_route(platform, request)
 
       assert error ==
                {:unknown_route,
@@ -73,21 +57,21 @@ defmodule Juvet.Router.PlatformFactoryTest do
       platform: platform
     } do
       route = Route.new(:command, "/test", to: "controller#action")
-      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
+      assert {:ok, route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an ok tuple with the route when the action route is valid to add", %{
       platform: platform
     } do
       route = Route.new(:action, "test_action", to: "controller#action")
-      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
+      assert {:ok, route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an ok tuple with the route when the view submission route is valid to add", %{
       platform: platform
     } do
       route = Route.new(:view_submission, "test_callback", to: "controller#action")
-      assert {:ok, route} = PlatformFactory.validate_route(platform, route)
+      assert {:ok, route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an error tuple with the route when the route is not valid", %{
@@ -102,7 +86,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
                  route: error_route,
                  options: %{}
                ]}} ==
-               PlatformFactory.validate_route(platform, error_route)
+               RouterFactory.validate_route(platform, error_route)
     end
 
     test "returns an error if the platform is not valid", %{route: route} do
@@ -110,7 +94,7 @@ defmodule Juvet.Router.PlatformFactoryTest do
 
       assert {:error,
               {:unknown_platform, [platform: unknown_platform, route: route, options: %{}]}} =
-               PlatformFactory.validate_route(
+               RouterFactory.validate_route(
                  unknown_platform,
                  route
                )

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -82,7 +82,7 @@ defmodule Juvet.Router.RouterFactoryTest do
       assert {:error,
               {:unknown_route,
                [
-                 platform: %SlackRouter{platform: %Platform{platform: :slack}},
+                 router: %SlackRouter{platform: %Platform{platform: :slack}},
                  route: error_route,
                  options: %{}
                ]}} ==

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -1,7 +1,7 @@
-defmodule Juvet.Router.SlackPlatformTest do
+defmodule Juvet.Router.SlackRouterTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.Router.{Platform, Request, Route, SlackPlatform}
+  alias Juvet.Router.{Platform, Request, Route, SlackRouter}
 
   describe "find_route/2" do
     setup do
@@ -11,7 +11,7 @@ defmodule Juvet.Router.SlackPlatformTest do
         Platform.new(:slack)
         |> Platform.put_route(route)
 
-      platform = SlackPlatform.new(platform)
+      platform = SlackRouter.new(platform)
 
       request = Request.new(%{params: %{"command" => "test"}})
       request = %{request | platform: :slack, verified?: true}
@@ -21,7 +21,7 @@ defmodule Juvet.Router.SlackPlatformTest do
 
     test "returns an ok tuple with the route if the request is a verified Slack command request",
          %{platform: platform, request: request} do
-      assert {:ok, route} = SlackPlatform.find_route(platform, request)
+      assert {:ok, route} = SlackRouter.find_route(platform, request)
       assert route.type == :command
       assert route.route == "/test"
       assert route.options == [to: "controller#action"]
@@ -34,7 +34,7 @@ defmodule Juvet.Router.SlackPlatformTest do
       request = %{request | verified?: false}
 
       assert {:error, {:unverified_route, [platform: platform, request: request]}} =
-               SlackPlatform.find_route(platform, request)
+               SlackRouter.find_route(platform, request)
     end
 
     test "returns an error tuple if the request is not found", %{
@@ -47,7 +47,7 @@ defmodule Juvet.Router.SlackPlatformTest do
       }
 
       assert {:error, {:unknown_route, [platform: platform, request: request]}} =
-               SlackPlatform.find_route(platform, request)
+               SlackRouter.find_route(platform, request)
     end
   end
 end

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -11,34 +11,34 @@ defmodule Juvet.Router.SlackRouterTest do
         Platform.new(:slack)
         |> Platform.put_route(route)
 
-      platform = SlackRouter.new(platform)
+      router = SlackRouter.new(platform)
 
       request = Request.new(%{params: %{"command" => "test"}})
       request = %{request | platform: :slack, verified?: true}
 
-      [platform: platform, request: request]
+      [router: router, request: request]
     end
 
     test "returns an ok tuple with the route if the request is a verified Slack command request",
-         %{platform: platform, request: request} do
-      assert {:ok, route} = SlackRouter.find_route(platform, request)
+         %{router: router, request: request} do
+      assert {:ok, route} = SlackRouter.find_route(router, request)
       assert route.type == :command
       assert route.route == "/test"
       assert route.options == [to: "controller#action"]
     end
 
     test "returns an error tuple with an unverified request", %{
-      platform: platform,
+      router: router,
       request: request
     } do
       request = %{request | verified?: false}
 
-      assert {:error, {:unverified_route, [platform: platform, request: request]}} =
-               SlackRouter.find_route(platform, request)
+      assert {:error, {:unverified_route, [router: router, request: request]}} =
+               SlackRouter.find_route(router, request)
     end
 
     test "returns an error tuple if the request is not found", %{
-      platform: platform,
+      router: router,
       request: request
     } do
       request = %{
@@ -46,8 +46,8 @@ defmodule Juvet.Router.SlackRouterTest do
         | params: Map.merge(request.params, %{"command" => "/blah"})
       }
 
-      assert {:error, {:unknown_route, [platform: platform, request: request]}} =
-               SlackRouter.find_route(platform, request)
+      assert {:error, {:unknown_route, [router: router, request: request]}} =
+               SlackRouter.find_route(router, request)
     end
   end
 end


### PR DESCRIPTION
This PR refactors the routing modules to be less complex and make use of [Behaviors](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours).

This was done after a lot more knowledge with Elixir. 😉

There was a lot of confusion what was a "platform" (platform definition as defined as a macro within `Juvet.Router`) which has the route definitions, and a "platform as a router" (meaning the platform that could find and validate routes based on the platform passed in as data).

So there is now 1 "Platform", which basically means the platform definition (routes, middleware, etc) and then several "platform-specific routers". These are modules that can find routes and validates routes based on their unique platform. Currently there are only 2, `SlackRouter` (previously `SlackPlatform`) and `UnknownRouter` (previously `UnknownPlatform`).

So now, you can think of Juvet as holding all the platforms...although, I imagine, in the future we would want to support one route -> multiple platforms as well as multiple platforms -> route, which this should allow the foundation for.

| Existing module | Replaced by | Notes |
| --- | --- | --- |
| `Juvet.Router.PlatformFactory` | `Juvet.Router.RouterFactory` | Routers now use platform definitions to find and validate routes. |
| `Juvet.Router.SlackPlatform` | `Juvet.Router.SlackRouter` | This now serves as only a router for Slack. It uses a platform to find and validate routes. Callbacks are specified in the `Router` now, which need to be defined on any "Router" |
| `Juvet.Router.UnknownPlatform` | `Juvet.Router.UnknownRouter` | This now serves as only a router for any unrecognized route. It returns all error paths since it should never be validated. Callbacks are specified in the `Router` now, which need to be defined on any "Router" |
| `Juvet.Router` | N/A | This is not being replaced but the router behavior defined will be used in each platform router |
| `Juvet.Router.Platform` | N/A | This represents solely a `platform` definition from configuration. It now only has functions that are for that purpose (no router functions). |