### PR TITLE
Add Controller Convience Methods

### DIFF
--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -7,15 +7,30 @@ defmodule Juvet.Controller do
 
   defmacro __using__(_opts) do
     quote do
-      @spec send_response(map(), Response.t() | nil) :: map()
+      @spec send_response(map() | String.t(), Response.t() | String.t() | map() | nil) :: map()
       def send_response(context, response \\ nil)
 
-      def send_response(context, nil), do: send_the_response(context)
+      def send_response(context, response) when is_binary(context),
+        do: send_url_response(context, response)
 
-      def send_response(context, %Response{} = response) do
+      def send_response(context, nil) when is_map(context), do: send_the_response(context)
+
+      def send_response(context, %Response{} = response) when is_map(context) do
         context = context |> maybe_update_response(response)
 
         send_the_response(context)
+      end
+
+      def send_response(context, response) when is_map(response),
+        do: send_response(context, Response.new(body: response))
+
+      defp send_url_response(url, %Response{body: body}), do: send_url_response(url, body)
+
+      defp send_url_response(url, response) when is_map(response),
+        do: send_url_response(url, response |> Poison.encode!())
+
+      defp send_url_response(url, response) when is_binary(response) do
+        HTTPoison.post!(url, response, [{"Content-Type", "application/json"}])
       end
 
       @spec update_response(map(), Response.t()) :: map()


### PR DESCRIPTION
This PR adds the ability to send a response from a controller via the conn with a map request. That will get turned into a `Juvet.Router.Response`. This allows users from not having to create a response object.

In addition, another overloaded parameters for `send_response` that takes in a url as the "context". This can be used to send messages back to Slack via a response url.
