### PR TITLE
Add base_url function for request

### DIFF
--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -48,10 +48,23 @@ defmodule Juvet.Router.Request do
     }
   end
 
+  def base_url(%__MODULE{host: host, port: port, scheme: scheme}) do
+    IO.iodata_to_binary([
+      to_string(scheme),
+      "://",
+      host,
+      base_url_port(scheme, port)
+    ])
+  end
+
   @spec get_header(Juvet.Router.Request.t(), String.t()) :: list(String.t())
   def get_header(%__MODULE__{headers: nil}, _header), do: []
 
   def get_header(%__MODULE__{headers: headers}, header) do
     for {^header, value} <- headers, do: value
   end
+
+  defp base_url_port(:http, 80), do: ""
+  defp base_url_port(:https, 443), do: ""
+  defp base_url_port(_, port), do: [?:, Integer.to_string(port)]
 end

--- a/lib/juvet/router/request.ex
+++ b/lib/juvet/router/request.ex
@@ -48,6 +48,7 @@ defmodule Juvet.Router.Request do
     }
   end
 
+  @spec base_url(Juvet.Router.Request.t()) :: String.t()
   def base_url(%__MODULE{host: host, port: port, scheme: scheme}) do
     IO.iodata_to_binary([
       to_string(scheme),

--- a/test/juvet/router/request_test.exs
+++ b/test/juvet/router/request_test.exs
@@ -39,6 +39,14 @@ defmodule Juvet.Router.RequestTest do
     end
   end
 
+  describe "base_url/1" do
+    test "returns a string as the base from the conn", %{conn: conn} do
+      request = Request.new(conn)
+
+      assert Request.base_url(request) == "http://www.example.com"
+    end
+  end
+
   describe "get_header/2" do
     setup %{conn: conn} do
       [request: Request.new(conn)]


### PR DESCRIPTION
This PR adds a function `Juvet.Router.Request.base_url/1` where it will return the base url for the request.

This can be used to get the base url within the templates for the bots.

Example usage:

```
Request.new(conn)
|> Request.base_url() # => "http://www.example.com"
```
