### PR TITLE
Fix Routing Configuration

### DIFF
--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -7,7 +7,7 @@ defmodule Juvet.Plug do
   """
 
   use Plug.Router
-  use Juvet.SlackRoutes, config: Juvet.configuration()
+  use Juvet.SlackRoutes
 
   alias Juvet.Router.Conn
 

--- a/lib/juvet/slack_routes.ex
+++ b/lib/juvet/slack_routes.ex
@@ -3,10 +3,10 @@ defmodule Juvet.SlackRoutes do
   Creates routes necessary for incoming Slack messages from configuration.
   """
 
-  defmacro __using__(opts) do
-    config = Keyword.get(opts, :config)
+  defmacro __using__(_opts) do
+    quote do
+      config = Juvet.configuration()
 
-    quote bind_quoted: [config: config] do
       if Juvet.Config.slack_configured?(config) do
         defaults = %{
           actions_endpoint: nil,


### PR DESCRIPTION
Classic example of using compile-time configuration vs. runtime configuration.

The issue was that calling `using SlackRoutes, config: Juvet.configuration()` and then binding that configuration at compile time is that the configuration has not been resolved yet.

We removed the using of the initial options and use runtime configuration to set the router.
