### PR TITLE
Add Chat SlackAPI Endpoints

### DIFF
--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -46,6 +46,27 @@ defmodule Juvet.SlackAPI.Chat do
   end
 
   @doc """
+  Share a me message into a channel.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: "C12345",
+    ts: "1417671948.000006"
+  } = Juvet.SlackAPI.Chat.me_message(%{token: token, channel: channel, text: text})
+  """
+  @spec me_message(map()) :: {:ok, map()} | {:error, map()}
+  def me_message(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.meMessage", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Creates a new message and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -6,6 +6,25 @@ defmodule Juvet.SlackAPI.Chat do
   alias Juvet.SlackAPI
 
   @doc """
+  Deletes a pending scheduled message.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Chat.delete_scheduled_message(%{token: token, channel: channel, scheduled_message_id: id})
+  """
+  @spec delete_scheduled_message(map()) :: {:ok, map()} | {:error, map()}
+  def delete_scheduled_message(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.deleteScheduledMessage", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Creates a new message and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -28,6 +28,31 @@ defmodule Juvet.SlackAPI.Chat do
   end
 
   @doc """
+  Schedules a new message for a specific timestamp and sends it to the channel specified.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: "C12345",
+    scheduled_message_id: "Q12345",
+    post_at: "1562180400",
+    message: {
+      text: "Hello World"
+    }
+  } = Juvet.SlackAPI.Chat.schedule_message(%{token: token, channel: channel, post_at: post_at, text: text})
+  """
+  @spec schedule_message(map()) :: {:ok, map()} | {:error, map()}
+  def schedule_message(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.scheduleMessage", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Updates an existing message based on the timestamp and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -25,6 +25,27 @@ defmodule Juvet.SlackAPI.Chat do
   end
 
   @doc """
+  Retrieve a permalink URL for a specific extant message.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: "C12345",
+    permalink: "https://slack.com/archives/M12345"
+  } = Juvet.SlackAPI.Chat.get_permalink(%{token: token, channel: channel, message_ts: ts})
+  """
+  @spec get_permalink(map()) :: {:ok, map()} | {:error, map()}
+  def get_permalink(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.getPermalink", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Creates a new message and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -72,6 +72,31 @@ defmodule Juvet.SlackAPI.Chat do
   end
 
   @doc """
+  Returns a list of scheduled messages.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    scheduled_messages: [%{
+      id: "Q12345",
+      channel_id: "C12345",
+      post_at: "1562180400",
+      text: "Hello World"
+    }]
+  } = Juvet.SlackAPI.Chat.schedule_messages_list(%{token: token})
+  """
+  @spec scheduled_messages_list(map()) :: {:ok, map()} | {:error, map()}
+  def scheduled_messages_list(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.scheduledMessages.list", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Updates an existing message based on the timestamp and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -67,6 +67,26 @@ defmodule Juvet.SlackAPI.Chat do
   end
 
   @doc """
+  Sends an ephemeral message to a user in a channel.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    message_ts: "1502210682.580145"
+  } = Juvet.SlackAPI.Chat.post_ephemeral(%{token: token, channel: channel, text: text, user: user})
+  """
+  @spec post_ephemeral(map()) :: {:ok, map()} | {:error, map()}
+  def post_ephemeral(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.postEphemeral", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Creates a new message and sends it to the channel specified.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/chat.ex
+++ b/lib/juvet/slack_api/chat.ex
@@ -181,6 +181,25 @@ defmodule Juvet.SlackAPI.Chat do
     |> SlackAPI.render_response()
   end
 
+  @doc """
+  Provide custom unfurl behavior for user-posted URLs
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Chat.unfurl(%{token: token, channel: channel, ts: timestamp, unfurls: unfurls})
+  """
+  @spec unfurl(map()) :: {:ok, map()} | {:error, map()}
+  def unfurl(options \\ %{}) do
+    options = options |> transform_options
+
+    SlackAPI.make_request("chat.unfurl", options)
+    |> SlackAPI.render_response()
+  end
+
   defp encode_blocks(nil), do: nil
   defp encode_blocks(blocks), do: Poison.encode!(blocks)
 

--- a/lib/juvet/slack_api/teams.ex
+++ b/lib/juvet/slack_api/teams.ex
@@ -1,4 +1,4 @@
-defmodule Juvet.SlackAPI.Team do
+defmodule Juvet.SlackAPI.Teams do
   @moduledoc """
   A wrapper around the team methods on the Slack API.
   """
@@ -17,7 +17,7 @@ defmodule Juvet.SlackAPI.Team do
     team: {
       id: "T123456"
     }
-  } = Juvet.SlackAPI.Team.info(%{token: token, team: team})
+  } = Juvet.SlackAPI.Teams.info(%{token: token, team: team})
   """
 
   @spec info(map()) :: {:ok, map()} | {:error, map()}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.0.3",
+      version: "0.1.0",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/slack_api/teams_test.exs
+++ b/test/juvet/slack_api/teams_test.exs
@@ -1,4 +1,4 @@
-defmodule Juvet.SlackAPI.TeamTest do
+defmodule Juvet.SlackAPI.TeamsTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
@@ -12,10 +12,10 @@ defmodule Juvet.SlackAPI.TeamTest do
     {:ok, team: "TEAM1", token: "TOKEN"}
   end
 
-  describe "SlackAPI.Team.info/1" do
+  describe "SlackAPI.Teams.info/1" do
     test "returns infomation about the team", %{team: team, token: token} do
       use_cassette "team/info/successful" do
-        assert {:ok, %{} = response} = SlackAPI.Team.info(%{team: team, token: token})
+        assert {:ok, %{} = response} = SlackAPI.Teams.info(%{team: team, token: token})
 
         assert response[:team][:id]
       end
@@ -26,7 +26,7 @@ defmodule Juvet.SlackAPI.TeamTest do
       token: token
     } do
       use_cassette "team/info/invalid_auth" do
-        assert {:error, %{} = response} = SlackAPI.Team.info(%{team: team, token: token})
+        assert {:error, %{} = response} = SlackAPI.Teams.info(%{team: team, token: token})
 
         assert response[:error] == "invalid_auth"
       end


### PR DESCRIPTION
This adds the following Slack api endpoints to the wrapper:

* chat.scheduleMessage
* chat.deleteScheduledMessage
* chat.scheduledMessages.list
* chat.getPermalink
* chat.meMessage
* chat.postEphemeral
* chat.unfurl

In addition, this fixes an inconsistency in the SlackAPI for teams.

The namespace was `Team` even though the slack api uses the plural `Teams`. Since our wrapper around the `Users` endpoint is plural to match, I decided to change the namespace to plural. Because of this change, we needed to bump the minor version since it breaks the SlackAPI wrapper.
