### PR TITLE
Slack API Conversation Methods

### DIFF
--- a/lib/juvet/slack_api/admin/conversations.ex
+++ b/lib/juvet/slack_api/admin/conversations.ex
@@ -1,0 +1,28 @@
+defmodule Juvet.SlackAPI.Admin.Conversations do
+  @moduledoc """
+  A wrapper around the administration conversations methods on the Slack API.
+  """
+
+  alias Juvet.SlackAPI
+
+  @doc """
+  Request to create a public or private channel-based conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel_id: "C12345"
+  } = Juvet.SlackAPI.Admin.Conversations.create(%{token: token, name: "CHANNEL1"})
+  """
+
+  @spec create(map()) :: {:ok, map()} | {:error, map()}
+  def create(options \\ %{}), do: render_response_to("admin.conversations.create", options)
+
+  defp render_response_to(endpoint, options) do
+    SlackAPI.make_request(endpoint, options)
+    |> SlackAPI.render_response()
+  end
+end

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -129,6 +129,24 @@ defmodule Juvet.SlackAPI.Conversations do
   end
 
   @doc """
+  Request to leave a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Conversations.leave(%{token: token, channel: "C12345"})
+  """
+
+  @spec leave(map()) :: {:ok, map()} | {:error, map()}
+  def leave(options \\ %{}) do
+    SlackAPI.make_request("conversations.leave", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve all the user ids for the users within a Conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -229,6 +229,27 @@ defmodule Juvet.SlackAPI.Conversations do
     |> SlackAPI.render_response()
   end
 
+  @doc """
+  Requests a set the topic for a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: {
+      id: "D123456"
+    }
+  } = Juvet.SlackAPI.Conversations.set_topic(%{token: token, channel: "C12345", topic: "Let's chat about this..."})
+  """
+
+  @spec set_topic(map()) :: {:ok, map()} | {:error, map()}
+  def set_topic(options \\ %{}) do
+    SlackAPI.make_request("conversations.setTopic", options)
+    |> SlackAPI.render_response()
+  end
+
   defp encode_users(nil), do: nil
   defp encode_users(users), do: Enum.join(users, ",")
 

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -88,6 +88,29 @@ defmodule Juvet.SlackAPI.Conversations do
   end
 
   @doc """
+  Request to join an existing conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel:%{
+      id: "C12345",
+      name: "CHANNEL1",
+      is_channel: true
+    }
+  } = Juvet.SlackAPI.Conversations.join(%{token: token, channel: "C12345"})
+  """
+
+  @spec join(map()) :: {:ok, map()} | {:error, map()}
+  def join(options \\ %{}) do
+    SlackAPI.make_request("conversations.join", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve all the user ids for the users within a Conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -111,6 +111,24 @@ defmodule Juvet.SlackAPI.Conversations do
   end
 
   @doc """
+  Request to remove a user from a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Conversations.kick(%{token: token, channel: "C12345", user: "U12345"})
+  """
+
+  @spec kick(map()) :: {:ok, map()} | {:error, map()}
+  def kick(options \\ %{}) do
+    SlackAPI.make_request("conversations.kick", options |> transform_options())
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve all the user ids for the users within a Conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -24,6 +24,24 @@ defmodule Juvet.SlackAPI.Conversations do
   end
 
   @doc """
+  Request to retrieve to close a a direct message or multi-person direct message.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Conversations.close(%{token: token, channel: "C12345"})
+  """
+
+  @spec close(map()) :: {:ok, map()} | {:error, map()}
+  def close(options \\ %{}) do
+    SlackAPI.make_request("conversations.close", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve to initiate a public or private channel-based conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -210,6 +210,25 @@ defmodule Juvet.SlackAPI.Conversations do
     |> SlackAPI.render_response()
   end
 
+  @doc """
+  Requests a sets the purpose for a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    purpose: "It's so very special"
+  } = Juvet.SlackAPI.Conversations.set_purpose(%{token: token, channel: "C12345", purpuse: "It's so very special"})
+  """
+
+  @spec set_purpose(map()) :: {:ok, map()} | {:error, map()}
+  def set_purpose(options \\ %{}) do
+    SlackAPI.make_request("conversations.setPurpose", options)
+    |> SlackAPI.render_response()
+  end
+
   defp encode_users(nil), do: nil
   defp encode_users(users), do: Enum.join(users, ",")
 

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -185,9 +185,28 @@ defmodule Juvet.SlackAPI.Conversations do
 
   @spec open(map()) :: {:ok, map()} | {:error, map()}
   def open(options \\ %{}) do
-    options = options |> transform_options
+    SlackAPI.make_request("conversations.open", options |> transform_options())
+    |> SlackAPI.render_response()
+  end
 
-    SlackAPI.make_request("conversations.open", options)
+  @doc """
+  Requests a rename for a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel: {
+      id: "D123456"
+    }
+  } = Juvet.SlackAPI.Conversations.rename(%{token: token, channel: "C12345", name: "something-new"})
+  """
+
+  @spec rename(map()) :: {:ok, map()} | {:error, map()}
+  def rename(options \\ %{}) do
+    SlackAPI.make_request("conversations.rename", options)
     |> SlackAPI.render_response()
   end
 

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -65,6 +65,29 @@ defmodule Juvet.SlackAPI.Conversations do
   end
 
   @doc """
+  Request to retrieve to invites users to a channel.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel:%{
+      id: "C12345",
+      name: "CHANNEL1",
+      is_channel: true
+    }
+  } = Juvet.SlackAPI.Conversations.invite(%{token: token, channel: "C12345", users: ["U12345", "U67890"]})
+  """
+
+  @spec invite(map()) :: {:ok, map()} | {:error, map()}
+  def invite(options \\ %{}) do
+    SlackAPI.make_request("conversations.invite", options |> transform_options())
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve all the user ids for the users within a Conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -6,6 +6,29 @@ defmodule Juvet.SlackAPI.Conversations do
   alias Juvet.SlackAPI
 
   @doc """
+  Request to retrieve to initiate a public or private channel-based conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    channel:%{
+      id: "C12345",
+      name: "CHANNEL1",
+      is_channel: true
+    }
+  } = Juvet.SlackAPI.Conversations.create(%{token: token, name: "CHANNEL1"})
+  """
+
+  @spec create(map()) :: {:ok, map()} | {:error, map()}
+  def create(options \\ %{}) do
+    SlackAPI.make_request("conversations.create", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve all the user ids for the users within a Conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -6,6 +6,24 @@ defmodule Juvet.SlackAPI.Conversations do
   alias Juvet.SlackAPI
 
   @doc """
+  Request to retrieve to archive a conversation.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Conversations.archive(%{token: token, channel: "C12345"})
+  """
+
+  @spec archive(map()) :: {:ok, map()} | {:error, map()}
+  def archive(options \\ %{}) do
+    SlackAPI.make_request("conversations.archive", options)
+    |> SlackAPI.render_response()
+  end
+
+  @doc """
   Request to retrieve to initiate a public or private channel-based conversation.
 
   Returns a map of the Slack response.

--- a/lib/juvet/slack_api/conversations.ex
+++ b/lib/juvet/slack_api/conversations.ex
@@ -250,6 +250,24 @@ defmodule Juvet.SlackAPI.Conversations do
     |> SlackAPI.render_response()
   end
 
+  @doc """
+  Requests a reverses to a conversation archival.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true
+  } = Juvet.SlackAPI.Conversations.unarchive(%{token: token, channel: "C12345"})
+  """
+
+  @spec unarchive(map()) :: {:ok, map()} | {:error, map()}
+  def unarchive(options \\ %{}) do
+    SlackAPI.make_request("conversations.unarchive", options)
+    |> SlackAPI.render_response()
+  end
+
   defp encode_users(nil), do: nil
   defp encode_users(users), do: Enum.join(users, ",")
 


### PR DESCRIPTION
This PR wraps several Conversation API methods so they can be called from within the library.

The following methods were added:

1. [admin.conversations.create](https://api.slack.com/methods/admin.conversations.create)
1. [conversations.create](https://api.slack.com/methods/conversations.create)
1. [conversations.archive](https://api.slack.com/methods/conversations.archive)
1. [conversations.close](https://api.slack.com/methods/conversations.close)
1. [conversations.invite](https://api.slack.com/methods/conversations.invite)
1. [conversations.join](https://api.slack.com/methods/conversations.join)
1. [conversations.kick](https://api.slack.com/methods/conversations.kick)
1. [conversations.leave](https://api.slack.com/methods/conversations.leave)
1. [conversations.rename](https://api.slack.com/methods/conversations.rename)
1. [conversations.setPurpose](https://api.slack.com/methods/conversations.setPurpose)
1. [conversations.setTopic](https://api.slack.com/methods/conversations.setTopic)
1. [conversations.unarchive](https://api.slack.com/methods/conversations.unarchive)
