### PR TITLE
Upgrade Elixir Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.10.4]
+        elixir: [1.14.1]
         otp: [24.1]
 
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.10
+erlang 24.1
+elixir 1.14.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :juvet,
   slack: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :plug, :validate_header_keys_during_test, false
 

--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -13,8 +13,6 @@ defmodule Juvet.Controller do
       def send_response(context, response) when is_binary(context),
         do: send_url_response(context, response)
 
-      def send_response(context, nil) when is_map(context), do: send_the_response(context)
-
       def send_response(context, %Response{} = response) when is_map(context) do
         context = context |> maybe_update_response(response)
 
@@ -23,6 +21,8 @@ defmodule Juvet.Controller do
 
       def send_response(context, response) when is_map(response),
         do: send_response(context, Response.new(body: response))
+
+      def send_response(context, nil) when is_map(context), do: send_the_response(context)
 
       defp send_url_response(url, %Response{body: body}), do: send_url_response(url, body)
 

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -114,11 +114,16 @@ defmodule Juvet.Router.SlackRouter do
 
   defp normalized_value(value), do: value |> String.trim() |> String.downcase()
 
-  defp view_submission_request?(%{params: %{"payload" => payload}}, callback_id) do
-    incoming_callback_id = payload |> Poison.decode!() |> callback_id_from_payload
+  defp view_submission_payload?(%{"type" => "view_submission"} = payload, callback_id) do
+    incoming_callback_id = payload |> callback_id_from_payload
 
     normalized_value(incoming_callback_id) == normalized_value(callback_id)
   end
+
+  defp view_submission_payload?(_payload, _callback_id), do: false
+
+  defp view_submission_request?(%{params: %{"payload" => payload}}, callback_id),
+    do: payload |> Poison.decode!() |> view_submission_payload?(callback_id)
 
   defp view_submission_request?(_request, _callback_id), do: false
 end

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -89,11 +89,16 @@ defmodule Juvet.Router.SlackRouter do
   defp action_from_payload(%{"actions" => actions}), do: List.first(actions)
   defp action_from_payload(_payload), do: %{}
 
-  defp action_request?(%{params: %{"payload" => payload}}, action_id) do
-    action = payload |> Poison.decode!() |> action_from_payload
+  defp action_payload?(%{"type" => "block_actions"} = payload, action_id) do
+    action = payload |> action_from_payload
 
     normalized_value(action["action_id"]) == normalized_value(action_id)
   end
+
+  defp action_payload?(_payload, _action_id), do: false
+
+  defp action_request?(%{params: %{"payload" => payload}}, action_id),
+    do: payload |> Poison.decode!() |> action_payload?(action_id)
 
   defp action_request?(_request, _action_id), do: false
 

--- a/lib/juvet/slack_signing_secret.ex
+++ b/lib/juvet/slack_signing_secret.ex
@@ -10,15 +10,10 @@ defmodule Juvet.SlackSigningSecret do
     do: generate(body, signing_secret, to_string(timestamp))
 
   def generate(body, signing_secret, timestamp) when is_binary(timestamp) do
-    "v0=#{
-      :crypto.mac(
-        :hmac,
-        :sha256,
-        signing_secret,
-        "v0:#{timestamp}:#{body}"
-      )
-      |> Base.encode16()
-    }"
+    "v0=#{:crypto.mac(:hmac,
+    :sha256,
+    signing_secret,
+    "v0:#{timestamp}:#{body}") |> Base.encode16()}"
     |> String.downcase()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.1.0",
-      elixir: "~> 1.10",
+      version: "0.2.0",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",
       deps: deps(),

--- a/test/juvet/middleware/action_runner_test.exs
+++ b/test/juvet/middleware/action_runner_test.exs
@@ -44,7 +44,7 @@ defmodule Juvet.Middleware.ActionRunnerTest do
     test "calls the controller module and action with the context", %{
       context: context
     } do
-      assert {:ok, ctx} = ActionRunner.call(Map.merge(context, %{pid: self()}))
+      assert {:ok, _ctx} = ActionRunner.call(Map.merge(context, %{pid: self()}))
 
       assert_received :called_controller
     end

--- a/test/juvet/middleware/route_request_test.exs
+++ b/test/juvet/middleware/route_request_test.exs
@@ -45,7 +45,7 @@ defmodule Juvet.Middleware.RouteRequestTest do
       assert {:error,
               %Juvet.RoutingError{
                 message: "No route found for the request.",
-                request: request
+                request: ^request
               }} = RouteRequest.call(context)
     end
 

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -57,21 +57,21 @@ defmodule Juvet.Router.RouterFactoryTest do
       platform: platform
     } do
       route = Route.new(:command, "/test", to: "controller#action")
-      assert {:ok, route} = RouterFactory.validate_route(platform, route)
+      assert {:ok, _route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an ok tuple with the route when the action route is valid to add", %{
       platform: platform
     } do
       route = Route.new(:action, "test_action", to: "controller#action")
-      assert {:ok, route} = RouterFactory.validate_route(platform, route)
+      assert {:ok, _route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an ok tuple with the route when the view submission route is valid to add", %{
       platform: platform
     } do
       route = Route.new(:view_submission, "test_callback", to: "controller#action")
-      assert {:ok, route} = RouterFactory.validate_route(platform, route)
+      assert {:ok, _route} = RouterFactory.validate_route(platform, route)
     end
 
     test "returns an error tuple with the route when the route is not valid", %{
@@ -94,7 +94,7 @@ defmodule Juvet.Router.RouterFactoryTest do
 
       assert {:error,
               {:unknown_platform,
-               [router: %UnknownRouter{platform: unknown_platform}, route: route, options: %{}]}} =
+               [router: %UnknownRouter{platform: ^unknown_platform}, route: ^route, options: %{}]}} =
                RouterFactory.validate_route(
                  unknown_platform,
                  route

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -33,7 +33,7 @@ defmodule Juvet.Router.SlackRouterTest do
     } do
       request = %{request | verified?: false}
 
-      assert {:error, {:unverified_route, [router: router, request: request]}} =
+      assert {:error, {:unverified_route, [router: ^router, request: ^request]}} =
                SlackRouter.find_route(router, request)
     end
 
@@ -46,7 +46,7 @@ defmodule Juvet.Router.SlackRouterTest do
         | params: Map.merge(request.params, %{"command" => "/blah"})
       }
 
-      assert {:error, {:unknown_route, [router: router, request: request]}} =
+      assert {:error, {:unknown_route, [router: ^router, request: ^request]}} =
                SlackRouter.find_route(router, request)
     end
   end


### PR DESCRIPTION
This PR upgrades Juvet from using Elixir 1.10 -> 1.14.

In addition, it fixes a bug with the Juvet router.

It now checks the type for the interactive payload from Slack. A route matches now for a view submission if the `type` is `view_submission`. In addition, a check was made for actions to ensure the payload has a type of `block_actions`.