### PR TITLE
view_closed Route for Slack

### DIFF
--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -51,6 +51,15 @@ defmodule Juvet.Router do
     end
   end
 
+  defmacro view_closed(callback_id, options \\ []) do
+    quote do
+      Router.State.put_route_on_top!(
+        __MODULE__,
+        Route.new(:view_closed, unquote(callback_id), unquote(options))
+      )
+    end
+  end
+
   defmacro view_submission(callback_id, options \\ []) do
     quote do
       Router.State.put_route_on_top!(

--- a/lib/juvet/router/state.ex
+++ b/lib/juvet/router/state.ex
@@ -64,12 +64,12 @@ defmodule Juvet.Router.State do
       {:error, {:unknown_route, route_info}} ->
         put_platform(module, platform)
 
-        platform = Keyword.fetch!(route_info, :platform)
+        router = Keyword.fetch!(route_info, :router)
         route = Keyword.fetch!(route_info, :route)
 
         raise RouteError,
           message:
-            "Route `#{route.route}` (#{route.type}) for `#{platform.platform.platform}` not found.",
+            "Route `#{route.route}` (#{route.type}) for `#{router.platform.platform}` not found.",
           router: module
     end
 

--- a/test/juvet/integration/slack_view_closed_test.exs
+++ b/test/juvet/integration/slack_view_closed_test.exs
@@ -1,0 +1,78 @@
+defmodule Juvet.Integration.SlackViewClosedTest do
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    platform :slack do
+      view_closed("closed",
+        to: "juvet.integration.slack_view_closed_test.test#closed"
+      )
+    end
+  end
+
+  defmodule TestController do
+    def closed(%{pid: pid} = context) do
+      send(pid, :called_controller)
+
+      {:ok, context}
+    end
+  end
+
+  def fixture(:valid_slack_view_closed, callback_id \\ "CALLBACK") do
+    view =
+      [
+        {"callback_id", callback_id}
+      ]
+      |> Enum.into(%{})
+
+    payload =
+      [
+        {"type", "view_closed"},
+        {"team", %{id: "T1234"}},
+        {"user", %{id: "U1234"}},
+        {"view", view},
+        {"is_cleared", true}
+      ]
+      |> Enum.into(%{})
+      |> Poison.encode!()
+
+    [
+      {"payload", payload}
+    ]
+    |> Enum.into(%{})
+  end
+
+  describe "with a valid Slack action" do
+    setup do
+      signing_secret = generate_slack_signing_secret()
+
+      [signing_secret: signing_secret]
+    end
+
+    test "is routed correctly", %{signing_secret: signing_secret} do
+      params = fixture(:valid_slack_view_closed, "closed")
+
+      conn =
+        request!(
+          :post,
+          "/slack/actions",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      # Request was successful and will not continue in the request chain
+      assert conn.halted
+
+      assert_received :called_controller
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the [view_closed](https://api.slack.com/reference/interaction-payloads/views#view_closed) route for "view_closed" payload events.

These events occur when the user closes a view and sets the `notify_on_close` boolean to `true`, then your app will receive these events.


