### PR TITLE
View State Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ end
 When Juvet starts, the following is what that process tree should look like.
 
 ```asciidoc
-                                            +----------+
-                                            |          |
-                                         +--| Endpoint |
-                                         |  |          |
-                                         |  +----------+
-  +---------------+    +--------------+--+  +----------------+
+                                            +------------------+     +-------------------+
+                                            |                  |-----| ViewStateRegistry |
+                                         +--| ViewStateManager |     +-------------------+
+                                         |  |                  |     +---------------------+
+                                         |  +------------------+-----| ViewStateSupervisor |
+  +---------------+    +--------------+--+  +----------------+       +---------------------+
   |               |    |              |     |                |
   |     Juvet     |----|  BotFactory  |-----| Superintendent |
   | (application) |    |              |     |                |
@@ -103,7 +103,12 @@ When Juvet starts, the following is what that process tree should look like.
   ```
 
   * **Juvet** - Application that starts the `Juvet.BotFactory` supervisor
-  * **BotFactory** - Supervisor that starts the `Juvet.Superintendent` process
+  * **BotFactory** - Supervisor that starts the `Juvet.Superintendent` and `Juvet.ViewStateManager` processes.
+  * **ViewStateManager** - Supervisor that can manage the storage of any arbitray piece of data for
+                           a given set of keys. Starts the `Juvet.ViewStateRegistry` and a dynamic supervisor
+                           for `Juvet.ViewState` processes.
+  * **ViewStateRegistry** - Server to act as a registry service to convert keys (as Tuples) into pids in order
+                            to identify `Juvet.ViewState` processes.
   * **Superintdendent** - The brains of the operation. Process checks the validity of the
                           configuration and if it is configured correctly, it starts
                           the `Juvet.Endpoint` process and the `Juvet.FactorySupervisor`

--- a/lib/juvet/bot_factory.ex
+++ b/lib/juvet/bot_factory.ex
@@ -148,6 +148,7 @@ defmodule Juvet.BotFactory do
   @impl true
   def init(config) do
     children = [
+      Juvet.ViewStateManager,
       {Juvet.Superintendent, config}
     ]
 

--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -5,7 +5,9 @@ defmodule Juvet.Controller do
 
   alias Juvet.Router.{Conn, Response}
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    view_state_manager = Keyword.get(opts, :view_state_manager, Juvet.ViewStateManager)
+
     quote do
       @spec send_response(map() | String.t(), Response.t() | String.t() | map() | nil) :: map()
       def send_response(context, response \\ nil)
@@ -38,6 +40,8 @@ defmodule Juvet.Controller do
       @spec update_response(map(), Response.t() | nil) :: map()
       def update_response(context, %Response{} = response),
         do: maybe_update_response(context, response)
+
+      def view_state, do: unquote(view_state_manager)
 
       defp send_the_response(context) do
         conn = Conn.send_resp(context)

--- a/lib/juvet/view_state.ex
+++ b/lib/juvet/view_state.ex
@@ -1,0 +1,86 @@
+defmodule Juvet.ViewState do
+  @moduledoc """
+  A process that can be used to store and retrieve changes across network requests.
+  """
+
+  use GenServer
+
+  alias Juvet.ViewStateRegistry
+
+  @registry ViewStateRegistry
+
+  @type t :: %__MODULE__{
+          key: tuple() | binary(),
+          value: any(),
+          pid: pid()
+        }
+  defstruct key: nil,
+            value: nil,
+            pid: nil
+
+  @spec exists?(pid()) :: true | false
+  def exists?(pid_or_key) when is_pid(pid_or_key), do: Process.alive?(pid_or_key)
+
+  @spec exists?(tuple() | binary()) :: true | false
+  def exists?(pid_or_key) do
+    case @registry.whereis_name(pid_or_key) do
+      :undefined -> false
+      _ -> GenServer.call(via(pid_or_key), :exists?)
+    end
+  end
+
+  @spec start(tuple() | binary(), any(), keyword()) :: {:ok, pid()} | {:error, any()}
+  def start(key, value, opts \\ []) do
+    GenServer.start(__MODULE__, %__MODULE__{key: key, value: value}, opts)
+  end
+
+  @spec start_link(tuple() | binary(), any(), keyword()) :: {:ok, pid()} | {:error, any()}
+  def start_link(key, value, opts \\ []) do
+    GenServer.start_link(__MODULE__, %__MODULE__{key: key, value: value}, opts)
+  end
+
+  @spec state(pid() | tuple() | binary()) :: Tatsu.Bot.ViewState.t() | nil
+  def state(pid_or_key), do: GenServer.call(via(pid_or_key), :state)
+
+  @spec stop(pid() | tuple() | binary()) :: Tatsu.Bot.ViewState.t() | nil
+  def stop(pid_or_key), do: GenServer.call(via(pid_or_key), :stop)
+
+  @spec update(pid() | tuple(), any()) :: :ok
+  def update(pid_or_key, value), do: GenServer.cast(via(pid_or_key), {:update, value})
+
+  @spec value(pid() | tuple() | binary()) :: any()
+  def value(pid_or_key), do: GenServer.call(via(pid_or_key), :value)
+
+  # Callbacks
+  def init(%__MODULE__{key: key} = state) do
+    pid = self()
+
+    @registry.register_name(key, pid)
+
+    {:ok, %{state | pid: pid}}
+  end
+
+  def handle_call(:exists?, _from, %__MODULE__{value: value} = state) do
+    {:reply, !!value, state}
+  end
+
+  def handle_call(:state, _from, %__MODULE__{} = state) do
+    {:reply, state, state}
+  end
+
+  def handle_call(:stop, _from, %__MODULE__{} = state) do
+    {:stop, :normal, state, state}
+  end
+
+  def handle_call(:value, _from, %__MODULE__{} = state) do
+    {:reply, state.value, state}
+  end
+
+  def handle_cast({:update, value}, %__MODULE__{} = state) do
+    {:noreply, %{state | value: value}}
+  end
+
+  defp via(pid_or_key) when is_pid(pid_or_key), do: pid_or_key
+
+  defp via(key), do: {:via, @registry, key}
+end

--- a/lib/juvet/view_state.ex
+++ b/lib/juvet/view_state.ex
@@ -39,10 +39,10 @@ defmodule Juvet.ViewState do
     GenServer.start_link(__MODULE__, %__MODULE__{key: key, value: value}, opts)
   end
 
-  @spec state(pid() | tuple() | binary()) :: Tatsu.Bot.ViewState.t() | nil
+  @spec state(pid() | tuple() | binary()) :: Juvet.ViewState.t() | nil
   def state(pid_or_key), do: GenServer.call(via(pid_or_key), :state)
 
-  @spec stop(pid() | tuple() | binary()) :: Tatsu.Bot.ViewState.t() | nil
+  @spec stop(pid() | tuple() | binary()) :: Juvet.ViewState.t() | nil
   def stop(pid_or_key), do: GenServer.call(via(pid_or_key), :stop)
 
   @spec update(pid() | tuple(), any()) :: :ok

--- a/lib/juvet/view_state_manager.ex
+++ b/lib/juvet/view_state_manager.ex
@@ -1,0 +1,64 @@
+defmodule Juvet.ViewStateManager do
+  @moduledoc """
+  A Supervisor process to handle the management of all the view state processes.
+  """
+
+  use Supervisor
+
+  alias Juvet.{ViewState, ViewStateRegistry}
+
+  @name __MODULE__
+  @supervisor :view_state_supervisor
+
+  def name, do: @name
+
+  def start_link(_), do: start_link()
+  def start_link, do: Supervisor.start_link(__MODULE__, [], name: name())
+
+  def stop, do: Supervisor.stop(name())
+
+  def retrieve(key), do: ViewState.value(key)
+
+  def remove(key), do: ViewState.stop(key)
+
+  def state(key), do: ViewState.state(key)
+
+  def store(key, value) do
+    case ViewState.exists?(key) do
+      true -> update_child(key, value)
+      false -> start_child(key, value)
+    end
+  end
+
+  defp start_child(key, value) do
+    DynamicSupervisor.start_child(
+      @supervisor,
+      %{
+        id: {ViewState, key},
+        start: {ViewState, :start_link, [key, value]},
+        restart: :transient
+      }
+    )
+  end
+
+  defp update_child(key, value) do
+    :ok = ViewState.update(key, value)
+
+    case ViewState.state(key) do
+      %{pid: pid} -> {:ok, pid}
+      nil -> {:error, :key_not_found}
+    end
+  end
+
+  # Callbacks
+
+  @impl true
+  def init(_) do
+    children = [
+      ViewStateRegistry,
+      {DynamicSupervisor, name: @supervisor, strategy: :one_for_one}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/juvet/view_state_registry.ex
+++ b/lib/juvet/view_state_registry.ex
@@ -1,0 +1,73 @@
+defmodule Juvet.ViewStateRegistry do
+  @moduledoc """
+  A process to keep track of what view state keys are registered. It is used as a Registry
+  for other processes for the view state in order to exchange a list of tuples for a name.
+  """
+
+  use GenServer
+
+  @name :view_state_registry
+
+  @spec start_link(any()) :: {:ok, pid()} | {:error, any()}
+  def start_link(_), do: GenServer.start_link(__MODULE__, [], name: @name)
+
+  @spec start_link() :: {:ok, pid()} | {:error, any()}
+  def start_link, do: GenServer.start_link(__MODULE__, [], name: @name)
+
+  @spec register_name(tuple() | binary(), pid()) :: :ok | :already_registered
+  def register_name(name, pid), do: GenServer.call(@name, {:register_name, name, pid})
+
+  @spec send(tuple() | binary(), any()) :: pid() | {:badarg, {tuple() | binary(), any()}}
+  def send(name, message) do
+    case whereis_name(name) do
+      :undefined ->
+        {:badarg, {name, message}}
+
+      pid ->
+        Kernel.send(pid, message)
+        pid
+    end
+  end
+
+  @spec unregister_name(tuple() | binary()) :: :ok
+  def unregister_name(name), do: GenServer.cast(@name, {:unregister_name, name})
+
+  @spec whereis_name(tuple() | binary()) :: pid() | :undefined
+  def whereis_name(name), do: GenServer.call(@name, {:whereis_name, name})
+
+  # Callbacks
+  def init(_) do
+    {:ok, Map.new()}
+  end
+
+  def handle_call({:register_name, name, pid}, _from, state) do
+    case state |> find_by_name(name) do
+      :undefined ->
+        Process.monitor(pid)
+        {:reply, :ok, state |> Map.put_new(name, pid)}
+
+      _ ->
+        {:reply, :already_registered, state}
+    end
+  end
+
+  def handle_call({:whereis_name, name}, _from, state) do
+    {:reply, state |> find_by_name(name), state}
+  end
+
+  def handle_cast({:unregister_name, name}, state) do
+    {:noreply, state |> Map.delete(name)}
+  end
+
+  def handle_info({:DOWN, _, :process, pid, _}, state) do
+    {:noreply, state |> remove_by_pid(pid)}
+  end
+
+  defp find_by_name(state, name), do: state |> Map.get(name, :undefined)
+
+  defp remove_by_pid(state, pid_to_remove) do
+    state
+    |> Enum.reject(fn {_key, pid} -> pid == pid_to_remove end)
+    |> Enum.into(%{})
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/controller_test.exs
+++ b/test/juvet/controller_test.exs
@@ -34,6 +34,14 @@ defmodule Juvet.ControllerTest do
     end
   end
 
+  describe "view_state/0" do
+    test "returns the view state manager" do
+      view_state = MyController.view_state()
+
+      assert view_state == Juvet.ViewStateManager
+    end
+  end
+
   describe "send_response/2" do
     setup do
       context = %{

--- a/test/juvet/view_state_manager_test.exs
+++ b/test/juvet/view_state_manager_test.exs
@@ -1,23 +1,18 @@
 defmodule Juvet.ViewStateManagerTest do
   use ExUnit.Case, async: false
 
-  alias Juvet.{ViewStateManager, ViewStateRegistry}
+  alias Juvet.ViewStateManager
 
   describe "start_link/0" do
     test "returns the pid" do
-      if Process.whereis(ViewStateManager.name()), do: ViewStateManager.stop()
-
-      assert {:ok, pid} = ViewStateManager.start_link()
+      assert {:ok, pid} = start_supervised(ViewStateManager)
       assert is_pid(pid)
     end
   end
 
   describe "store/3" do
     setup do
-      ViewStateManager.start_link()
-
-      if !Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.start_link()
-
+      start_supervised!(ViewStateManager)
       :ok
     end
 

--- a/test/juvet/view_state_manager_test.exs
+++ b/test/juvet/view_state_manager_test.exs
@@ -1,0 +1,47 @@
+defmodule Juvet.ViewStateManagerTest do
+  use ExUnit.Case, async: false
+
+  alias Juvet.{ViewStateManager, ViewStateRegistry}
+
+  describe "start_link/0" do
+    test "returns the pid" do
+      if Process.whereis(ViewStateManager.name()), do: ViewStateManager.stop()
+
+      assert {:ok, pid} = ViewStateManager.start_link()
+      assert is_pid(pid)
+    end
+  end
+
+  describe "store/3" do
+    setup do
+      ViewStateManager.start_link()
+
+      if !Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.start_link()
+
+      :ok
+    end
+
+    test "starts a view state process for a specific key" do
+      key = {"T1234", "U1234", "C1234", :update_participants}
+
+      assert {:ok, pid} = ViewStateManager.store(key, %{some: "value"})
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+
+      assert ViewStateManager.state(key) == %Juvet.ViewState{
+               pid: pid,
+               key: key,
+               value: %{some: "value"}
+             }
+    end
+
+    test "updates a view if it already exists" do
+      key = {"T1234", "U1234", "C1234", :update_participants}
+
+      {:ok, first_pid} = ViewStateManager.store(key, %{some: "value"})
+      {:ok, second_pid} = ViewStateManager.store(key, %{other: "changed"})
+
+      assert first_pid == second_pid
+    end
+  end
+end

--- a/test/juvet/view_state_registry_test.exs
+++ b/test/juvet/view_state_registry_test.exs
@@ -3,23 +3,19 @@ defmodule Juvet.ViewStateRegistryTest do
 
   alias Juvet.ViewStateRegistry
 
-  setup_all do
-    if Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.stop()
+  def shut_down_registry(), do: shut_down_registry(nil)
 
+  def shut_down_registry(_context) do
+    if(Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.stop())
     :ok
   end
 
-  describe "start_link" do
-    test "returns the pid" do
-      assert {:ok, pid} = ViewStateRegistry.start_link()
-      assert is_pid(pid)
-    end
-  end
+  setup_all :shut_down_registry
 
   describe "register_name/2" do
     setup do
-      ViewStateRegistry.start_link()
-
+      start_supervised(ViewStateRegistry)
+      on_exit(&shut_down_registry/0)
       :ok
     end
 
@@ -56,8 +52,8 @@ defmodule Juvet.ViewStateRegistryTest do
 
   describe "send/2" do
     setup do
-      ViewStateRegistry.start_link()
-
+      start_supervised(ViewStateRegistry)
+      on_exit(&shut_down_registry/0)
       :ok
     end
 
@@ -82,8 +78,8 @@ defmodule Juvet.ViewStateRegistryTest do
 
   describe "unregister_name/1" do
     setup do
-      ViewStateRegistry.start_link()
-
+      start_supervised(ViewStateRegistry)
+      on_exit(&shut_down_registry/0)
       :ok
     end
 

--- a/test/juvet/view_state_registry_test.exs
+++ b/test/juvet/view_state_registry_test.exs
@@ -1,0 +1,92 @@
+defmodule Juvet.ViewStateRegistryTest do
+  use ExUnit.Case, async: false
+
+  alias Juvet.ViewStateRegistry
+
+  describe "start_link" do
+    test "returns the pid" do
+      assert {:ok, pid} = ViewStateRegistry.start_link()
+      assert is_pid(pid)
+    end
+  end
+
+  describe "register_name/2" do
+    setup do
+      {:ok, pid} = ViewStateRegistry.start_link()
+
+      [pid: pid]
+    end
+
+    test "registers the name with the pid for lookup" do
+      :ok = ViewStateRegistry.register_name({:this, :is, :a, :key}, self())
+
+      pid = ViewStateRegistry.whereis_name({:this, :is, :a, :key})
+
+      assert pid == self()
+    end
+
+    test "does not register a name again that already exists" do
+      assert :ok = ViewStateRegistry.register_name({:this, :is, :a, :key}, self())
+
+      assert :already_registered =
+               ViewStateRegistry.register_name(
+                 {:this, :is, :a, :key},
+                 spawn(fn -> nil end)
+               )
+    end
+
+    test "removes the name when the process dies" do
+      name = {:another, :key}
+
+      pid = spawn(fn -> nil end)
+
+      :ok = ViewStateRegistry.register_name(name, pid)
+
+      pid |> Process.exit(:kill)
+
+      assert :undefined = ViewStateRegistry.whereis_name(name)
+    end
+  end
+
+  describe "send/2" do
+    setup do
+      {:ok, pid} = ViewStateRegistry.start_link()
+
+      [pid: pid]
+    end
+
+    test "sends the process a message based on the name" do
+      name = {:send, :me, :a, :message}
+      :ok = ViewStateRegistry.register_name(name, self())
+
+      pid = ViewStateRegistry.send(name, :message)
+
+      assert pid == self()
+      assert_received :message
+    end
+
+    test "does not send a message if the process cannot be found" do
+      name = {:send, :me, :a, :message}
+      :ok = ViewStateRegistry.register_name(name, self())
+      :ok = ViewStateRegistry.unregister_name(name)
+
+      assert {:badarg, {^name, :message}} = ViewStateRegistry.send(name, :message)
+    end
+  end
+
+  describe "unregister_name/1" do
+    setup do
+      {:ok, pid} = ViewStateRegistry.start_link()
+
+      [pid: pid]
+    end
+
+    test "removes the name from lookup" do
+      name = {:this, :key, :works}
+      :ok = ViewStateRegistry.register_name(name, self())
+
+      assert :ok = ViewStateRegistry.unregister_name(name)
+      assert :undefined = ViewStateRegistry.whereis_name(name)
+    end
+  end
+end

--- a/test/juvet/view_state_registry_test.exs
+++ b/test/juvet/view_state_registry_test.exs
@@ -3,6 +3,12 @@ defmodule Juvet.ViewStateRegistryTest do
 
   alias Juvet.ViewStateRegistry
 
+  setup_all do
+    if Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.stop()
+
+    :ok
+  end
+
   describe "start_link" do
     test "returns the pid" do
       assert {:ok, pid} = ViewStateRegistry.start_link()
@@ -12,9 +18,9 @@ defmodule Juvet.ViewStateRegistryTest do
 
   describe "register_name/2" do
     setup do
-      {:ok, pid} = ViewStateRegistry.start_link()
+      ViewStateRegistry.start_link()
 
-      [pid: pid]
+      :ok
     end
 
     test "registers the name with the pid for lookup" do
@@ -50,9 +56,9 @@ defmodule Juvet.ViewStateRegistryTest do
 
   describe "send/2" do
     setup do
-      {:ok, pid} = ViewStateRegistry.start_link()
+      ViewStateRegistry.start_link()
 
-      [pid: pid]
+      :ok
     end
 
     test "sends the process a message based on the name" do
@@ -76,9 +82,9 @@ defmodule Juvet.ViewStateRegistryTest do
 
   describe "unregister_name/1" do
     setup do
-      {:ok, pid} = ViewStateRegistry.start_link()
+      ViewStateRegistry.start_link()
 
-      [pid: pid]
+      :ok
     end
 
     test "removes the name from lookup" do

--- a/test/juvet/view_state_registry_test.exs
+++ b/test/juvet/view_state_registry_test.exs
@@ -3,7 +3,7 @@ defmodule Juvet.ViewStateRegistryTest do
 
   alias Juvet.ViewStateRegistry
 
-  def shut_down_registry(), do: shut_down_registry(nil)
+  def shut_down_registry, do: shut_down_registry(nil)
 
   def shut_down_registry(_context) do
     if(Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.stop())

--- a/test/juvet/view_state_test.exs
+++ b/test/juvet/view_state_test.exs
@@ -1,0 +1,134 @@
+defmodule Juvet.ViewStateTest do
+  use ExUnit.Case, async: false
+
+  alias Juvet.{ViewState, ViewStateRegistry}
+
+  setup_all do
+    ViewStateRegistry.start_link()
+
+    :ok
+  end
+
+  describe "exists?/1" do
+    setup do
+      key = {:my, :unique, :key}
+
+      {:ok, pid} = ViewState.start(key, "This is a value")
+
+      on_exit(fn ->
+        if ViewState.exists?(key), do: ViewState.stop(pid)
+      end)
+
+      [pid: pid, key: key]
+    end
+
+    test "returns true if the view state exists via key", %{key: key} do
+      assert ViewState.exists?(key)
+    end
+
+    test "returns false if the view state does not exists via key", %{key: key} do
+      ViewState.stop(key)
+
+      refute ViewState.exists?(key)
+    end
+  end
+
+  describe "start/3" do
+    setup do
+      key = {:key, :view, :state}
+
+      on_exit(fn -> ViewState.stop(key) end)
+
+      [key: key]
+    end
+
+    test "returns the pid", %{key: key} do
+      assert {:ok, pid} = ViewState.start(key, :value)
+      assert is_pid(pid)
+    end
+  end
+
+  describe "state/1" do
+    setup do
+      key = {:my, :view, :state}
+
+      on_exit(fn -> ViewState.stop(key) end)
+
+      [key: key]
+    end
+
+    test "returns the state via pid", %{key: key} do
+      {:ok, pid} = ViewState.start(key, :value)
+
+      state = ViewState.state(pid)
+
+      assert %ViewState{
+               pid: pid,
+               key: key,
+               value: :value
+             } == state
+    end
+
+    test "returns the state via key", %{key: key} do
+      {:ok, pid} = ViewState.start(key, :value)
+
+      state = ViewState.state(key)
+
+      assert %ViewState{
+               pid: pid,
+               key: key,
+               value: :value
+             } == state
+    end
+  end
+
+  describe "stop/1" do
+    setup do
+      {:ok, pid} = ViewState.start(:key, :value)
+
+      [pid: pid]
+    end
+
+    test "stops the process", %{pid: pid} do
+      state = ViewState.stop(pid)
+
+      refute Process.alive?(state.pid)
+    end
+  end
+
+  describe "update/2" do
+    setup do
+      {:ok, pid} = ViewState.start({:my, :key}, "This is some value")
+
+      on_exit(fn -> ViewState.stop(pid) end)
+
+      [pid: pid]
+    end
+
+    test "updates the current value via pid", %{pid: pid} do
+      ViewState.update(pid, "This is a new value")
+
+      actual = ViewState.value(pid)
+
+      assert actual == "This is a new value"
+    end
+  end
+
+  describe "value/1" do
+    setup do
+      value = "This is stored"
+
+      {:ok, pid} = ViewState.start({:my, :key}, value)
+
+      on_exit(fn -> ViewState.stop(pid) end)
+
+      [pid: pid, value: value]
+    end
+
+    test "returns the current value via pid", %{pid: pid, value: value} do
+      actual = ViewState.value(pid)
+
+      assert actual == value
+    end
+  end
+end

--- a/test/juvet_test.exs
+++ b/test/juvet_test.exs
@@ -12,6 +12,10 @@ defmodule Juvet.JuvetTest do
       assert Process.whereis(Juvet.BotFactory) |> Process.alive?()
     end
 
+    test "starts the view state manager" do
+      assert Process.whereis(Juvet.ViewStateManager) |> Process.alive?()
+    end
+
     test "starts the Superintendent" do
       assert Process.whereis(Juvet.Superintendent) |> Process.alive?()
     end


### PR DESCRIPTION
This PR introduces a new GenServer for managing view state.

`ViewStateManager` is a Supervisor that has a DynamicSupervisor and a registry (`ViewStateRegistry`).

The GenServer allows a controller to store arbitrary values by keys so that data can be worked on in process without the need to serialize those changes back into the view. Depending on the features of the platform, storing or serializing that data is not usually feasable without an external storage system. The `ViewStateManager` is that process.

In addition, a `JuvetController` has a `view_state/0` function which takes in a hard-coded (for now) `Juvet.ViewStateManager`. It will be configurable in the future so clients can swap out the view state manager.

This will allow a controller to use it as such:

```
defmodule MyController do
  use Juvet.Controller

  def edit(context) do
    stored = view_state().retrieve({:team_id, :user_id, :topic})

    # perform some operations on stored

    view_state().store({:team_id, :user_id, :topic}, stored)
  end
end
```
