### PR TITLE
Fix an issue when parameters were not normalized for a Slack command

### DIFF
--- a/lib/juvet/gregorian_date_time.ex
+++ b/lib/juvet/gregorian_date_time.ex
@@ -5,6 +5,9 @@ defmodule Juvet.GregorianDateTime do
 
   @unix_gregorian_offset 62_167_219_200
 
+  @doc """
+  This calculates the number of seconds for a specific `NaiveDateTime`.
+  """
   @spec to_seconds(NaiveDateTime.t()) :: integer()
   def to_seconds(date_time \\ NaiveDateTime.utc_now()) do
     timestamp =

--- a/lib/juvet/router/request_param_normalizer.ex
+++ b/lib/juvet/router/request_param_normalizer.ex
@@ -20,10 +20,12 @@ defmodule Juvet.Router.RequestParamNormalizer do
       %{request | params: normalized_payload(payload)}
     end
 
-    def normalize(%Request{raw_params: _raw_params} = request), do: request
+    def normalize(%Request{raw_params: raw_params} = request),
+      do: %{request | params: normalized_payload(raw_params)}
 
     defp channel_id(%{"channel" => %{"id" => channel_id}}), do: channel_id
     defp channel_id(%{"channel" => channel_id}), do: channel_id
+    defp channel_id(%{"channel_id" => channel_id}), do: channel_id
     defp channel_id(_payload), do: nil
 
     defp team_id(%{"team" => %{"id" => team_id}}), do: team_id
@@ -32,6 +34,7 @@ defmodule Juvet.Router.RequestParamNormalizer do
 
     defp user_id(%{"user" => %{"id" => user_id}}), do: user_id
     defp user_id(%{"user" => user_id}), do: user_id
+    defp user_id(%{"user_id" => user_id}), do: user_id
     defp user_id(_payload), do: nil
 
     defp normalized_event(%{"event" => event} = params),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/middleware/normalize_request_params_test.exs
+++ b/test/juvet/middleware/normalize_request_params_test.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Middleware.NormalizeRequestParamsTest do
   alias Juvet.Middleware.NormalizeRequestParams
   alias Juvet.Router.Request
 
-  describe "call/1" do
+  describe "call/1 for a slack payload request" do
     setup do
       params = %{
         "payload" => %{
@@ -19,7 +19,7 @@ defmodule Juvet.Middleware.NormalizeRequestParamsTest do
       [context: %{request: %{request | platform: :slack}}]
     end
 
-    test "decodes the request parameters based on the request platform", %{context: context} do
+    test "decodes the request parameters", %{context: context} do
       assert {:ok,
               %{request: %{params: %{channel_id: channel_id, team_id: team_id, user_id: user_id}}}} =
                NormalizeRequestParams.call(context)
@@ -28,8 +28,34 @@ defmodule Juvet.Middleware.NormalizeRequestParamsTest do
       assert team_id == "T12345"
       assert user_id == "U12345"
     end
+  end
 
-    test "does not normalize parameters if there is no request" do
+  describe "call/1 for a slack command request" do
+    setup do
+      params = %{
+        "channel_id" => "C12345",
+        "team_id" => "T12345",
+        "user_id" => "U12345"
+      }
+
+      request = Request.new(%{params: params})
+
+      [context: %{request: %{request | platform: :slack}}]
+    end
+
+    test "decodes the request parameters", %{context: context} do
+      assert {:ok,
+              %{request: %{params: %{channel_id: channel_id, team_id: team_id, user_id: user_id}}}} =
+               NormalizeRequestParams.call(context)
+
+      assert channel_id == "C12345"
+      assert team_id == "T12345"
+      assert user_id == "U12345"
+    end
+  end
+
+  describe "call/1 for no request" do
+    test "does not normalize parameters" do
       assert {:ok, context} = NormalizeRequestParams.call(%{})
       refute Map.get(context, :request)
     end


### PR DESCRIPTION
This PR fixes an issue with the `NormalizeRequestParams` middleware did not work for Slack command payloads.

A Slack command request looks similar to the following:

```
{
  "channel_id": "C1234",
  "team_id": "T1234",
  "user_id": "U1234"
}
```

This did not add the params because it did not have a `payload` nor `event` parent node.
