### PR TITLE
Request Format on Router/Controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         cache-name: cache-plts
       with:
         path: priv/plts
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
 
     - name: Create PLTs
       if: steps.plt-cache.outputs.cache-hit != 'true'

--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -5,7 +5,7 @@ defmodule Juvet.Controller do
 
   @view_context_key :juvet_view
 
-  alias Juvet.Router.{Conn, Response}
+  alias Juvet.Router.{Conn, Request, Response, RouterFactory}
   alias Juvet.{View, ViewStateManager}
 
   defmacro __using__(opts) do
@@ -59,6 +59,13 @@ defmodule Juvet.Controller do
 
   @spec put_view(map(), String.t() | atom()) :: map()
   def put_view(context, view), do: Map.put(context, @view_context_key, view)
+
+  def request_format(%{request: %Request{platform: platform}} = context) do
+    case RouterFactory.router(platform).request_format(context) do
+      {:ok, format} -> format
+      {:error, error} -> error
+    end
+  end
 
   def send_message_from(controller, context, template, assigns \\ []),
     do: send_message_from(controller, context, template, assigns, [])

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -156,6 +156,9 @@ defmodule Juvet.Router do
   @callback handle_route(%{platform: Juvet.Router.Platform.t()}) ::
               {:ok, Juvet.Router.Route.t()} | {:error, term()}
 
+  @callback request_format(%{platform: Juvet.Router.Platform.t() | atom()}) ::
+              {:ok, atom()} | {:error, term()}
+
   @callback validate(Juvet.Router.Platform.t()) ::
               {:ok, Juvet.Router.Platform.t()} | {:error, term()}
 

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -156,7 +156,10 @@ defmodule Juvet.Router do
   @callback handle_route(%{platform: Juvet.Router.Platform.t()}) ::
               {:ok, Juvet.Router.Route.t()} | {:error, term()}
 
-  @callback request_format(%{platform: Juvet.Router.Platform.t() | atom()}) ::
+  @callback request_format(%{
+              platform: Juvet.Router.Platform.t() | atom(),
+              request: Juvet.Router.Request.t()
+            }) ::
               {:ok, atom()} | {:error, term()}
 
   @callback validate(Juvet.Router.Platform.t()) ::

--- a/lib/juvet/router/router_factory.ex
+++ b/lib/juvet/router/router_factory.ex
@@ -18,7 +18,10 @@ defmodule Juvet.Router.RouterFactory do
   end
 
   @spec router(Juvet.Router.Platform.t()) :: module()
-  def router(%Juvet.Router.Platform{platform: platform}) do
+  def router(%Juvet.Router.Platform{platform: platform}), do: router(platform)
+
+  @spec router(atom()) :: module()
+  def router(platform) do
     String.to_existing_atom("Elixir.Juvet.Router.#{Macro.camelize(to_string(platform))}Router")
   rescue
     _ in ArgumentError -> UnknownRouter

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -84,6 +84,14 @@ defmodule Juvet.Router.SlackRouter do
   def handle_route(context), do: {:ok, context}
 
   @impl Juvet.Router
+  def request_format(%{request: %{raw_params: %{"event" => event}}}),
+    do: request_format_from_event(event)
+
+  @impl Juvet.Router
+  def request_format(%{request: %{raw_params: %{"payload" => payload}}}),
+    do: request_format_from_payload(payload)
+
+  @impl Juvet.Router
   def validate(%{platform: :slack} = platform), do: {:ok, platform}
 
   @impl Juvet.Router
@@ -197,6 +205,19 @@ defmodule Juvet.Router.SlackRouter do
     do: payload |> block_suggestion_payload?(action_id)
 
   defp option_load_request?(_payload, _action_id), do: false
+
+  defp request_format_from_event(%{"type" => "app_home_opened", "view" => _}),
+    do: {:ok, :page}
+
+  defp request_format_from_event(_event), do: {:ok, :none}
+
+  defp request_format_from_payload(%{"message" => %{"ts" => _}, "response_url" => _}),
+    do: {:ok, :message}
+
+  defp request_format_from_payload(%{"container" => %{"type" => "view"}, "view" => _}),
+    do: {:ok, :modal}
+
+  defp request_format_from_payload(_payload), do: {:ok, :none}
 
   defp url_verification_request?(%{
          raw_params: %{"challenge" => _challenge, "type" => "url_verification"}

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -27,6 +27,9 @@ defmodule Juvet.Router.UnknownRouter do
   def handle_route(_context), do: {:error, :unknown_platform}
 
   @impl Juvet.Router
+  def request_format(_context), do: {:error, :unknown_platform}
+
+  @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}
 
   @impl Juvet.Router

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.5.2",
+      version: "0.5.3",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/controller_test.exs
+++ b/test/juvet/controller_test.exs
@@ -28,7 +28,7 @@ defmodule Juvet.ControllerTest do
   end
 
   alias Controllers.MyController
-  alias Juvet.Router.Response
+  alias Juvet.Router.{Request, Response}
 
   describe "controller_prefix/1" do
     test "returns the module name without controller suffix" do
@@ -47,6 +47,22 @@ defmodule Juvet.ControllerTest do
 
     test "returns an empty string when nil is provided with a suffix" do
       assert Juvet.Controller.controller_prefix(nil, suffix: ".") == ""
+    end
+  end
+
+  describe "request_format/1" do
+    test "returns :message if the request is from a Slack message" do
+      payload = %{
+        "message" => %{
+          "ts" => "1234567890.123456"
+        },
+        "response_url" => "https://hooks.slack.com/commands/1234/5678"
+      }
+
+      request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
+      context = %{request: request}
+
+      assert Juvet.Controller.request_format(context) == :message
     end
   end
 

--- a/test/juvet/router/router_factory_test.exs
+++ b/test/juvet/router/router_factory_test.exs
@@ -64,6 +64,18 @@ defmodule Juvet.Router.RouterFactoryTest do
     end
   end
 
+  describe "router/1" do
+    test "returns a module based on the platform" do
+      platform = Platform.new(:slack)
+
+      assert SlackRouter == RouterFactory.router(platform)
+    end
+
+    test "returns a module based on the platform as an atom" do
+      assert SlackRouter == RouterFactory.router(:slack)
+    end
+  end
+
   describe "validate_route/3" do
     setup do
       route = Route.new(:command, "/test", to: "controller#action")

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -50,4 +50,52 @@ defmodule Juvet.Router.SlackRouterTest do
                SlackRouter.find_route(router, request)
     end
   end
+
+  describe "request_format/1" do
+    test "returns :message when the payload has a message request" do
+      payload = %{
+        "message" => %{"ts" => "1234567890.123456"},
+        "response_url" => "https://example.com"
+      }
+
+      request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
+      context = %{request: request}
+
+      assert SlackRouter.request_format(context) == {:ok, :message}
+    end
+
+    test "returns :modal when the payload has a modal request" do
+      payload = %{
+        "container" => %{"type" => "view"},
+        "view" => %{"id" => "V12345"}
+      }
+
+      request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
+      context = %{request: request}
+
+      assert SlackRouter.request_format(context) == {:ok, :modal}
+    end
+
+    test "returns :page when the params has a home tab request" do
+      raw_params = %{
+        "event" => %{"type" => "app_home_opened", "view" => %{"id" => "V12345"}}
+      }
+
+      request = %Request{platform: :slack, raw_params: raw_params}
+      context = %{request: request}
+
+      assert SlackRouter.request_format(context) == {:ok, :page}
+    end
+
+    test "returns :none when the params has any other event request" do
+      raw_params = %{
+        "event" => %{"type" => "channel_rename", "channel" => %{"id" => "C12345"}}
+      }
+
+      request = %Request{platform: :slack, raw_params: raw_params}
+      context = %{request: request}
+
+      assert SlackRouter.request_format(context) == {:ok, :none}
+    end
+  end
 end


### PR DESCRIPTION
This PR allows for a controller to find what the current `request_format` is for a given request within a context.

This new function will look at the structure of the raw params (within it's own platform's router) and determine what the "surface" of the request came from.

For example, in Slack, we know that a request came from message if the request has a payload and a message field.

This PR determines these surfaces for the `SlackRouter` and `UnknownRouter`.

For the `UnknownRouter`, it always returns an error tuple with `unknown_platform` error.

For the `SlackRouter`, the following is determined currently. There is possibly more found in the future but these are what are currently supported:

* `:message` format - When the request is coming from the "Message" surface
* `:modal` format - When the request is coming from a "View Submission"
* `:page` format - When the request is coming from the `app_home_opened` event

This will allow the controllers to determine the request format and perform specific code for those formats:

```
defmodule My.Bot.Controllers.TaskController do
  def edit(context) do
    case request_format(context) do
      :message ->
        # Get the timestamp and record it for update later
      :modal ->
        # Respond with an updated modal
    end
  end
end
```
