### PR TITLE
Use the imported request_format/1

### DIFF
--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -25,6 +25,8 @@ defmodule Juvet.Controller do
     view_state_manager = Keyword.get(opts, :view_state_manager, ViewStateManager)
 
     quote do
+      def request_format(%{request: request}), do: request_format_from(request)
+
       def send_message(context, template, assigns \\ []),
         do: send_message_from(__MODULE__, context, template, assigns)
 
@@ -60,8 +62,8 @@ defmodule Juvet.Controller do
   @spec put_view(map(), String.t() | atom()) :: map()
   def put_view(context, view), do: Map.put(context, @view_context_key, view)
 
-  def request_format(%{request: %Request{platform: platform}} = context) do
-    case RouterFactory.router(platform).request_format(context) do
+  def request_format_from(%Request{platform: platform} = request) do
+    case RouterFactory.router(platform).request_format(request) do
       {:ok, format} -> format
       {:error, error} -> error
     end

--- a/lib/juvet/router.ex
+++ b/lib/juvet/router.ex
@@ -156,11 +156,7 @@ defmodule Juvet.Router do
   @callback handle_route(%{platform: Juvet.Router.Platform.t()}) ::
               {:ok, Juvet.Router.Route.t()} | {:error, term()}
 
-  @callback request_format(%{
-              platform: Juvet.Router.Platform.t() | atom(),
-              request: Juvet.Router.Request.t()
-            }) ::
-              {:ok, atom()} | {:error, term()}
+  @callback request_format(Juvet.Router.Request.t()) :: {:ok, atom()} | {:error, term()}
 
   @callback validate(Juvet.Router.Platform.t()) ::
               {:ok, Juvet.Router.Platform.t()} | {:error, term()}

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -84,11 +84,11 @@ defmodule Juvet.Router.SlackRouter do
   def handle_route(context), do: {:ok, context}
 
   @impl Juvet.Router
-  def request_format(%{request: %{raw_params: %{"event" => event}}}),
+  def request_format(%{raw_params: %{"event" => event}}),
     do: request_format_from_event(event)
 
   @impl Juvet.Router
-  def request_format(%{request: %{raw_params: %{"payload" => payload}}}),
+  def request_format(%{raw_params: %{"payload" => payload}}),
     do: request_format_from_payload(payload)
 
   @impl Juvet.Router

--- a/lib/juvet/router/unknown_router.ex
+++ b/lib/juvet/router/unknown_router.ex
@@ -27,7 +27,7 @@ defmodule Juvet.Router.UnknownRouter do
   def handle_route(_context), do: {:error, :unknown_platform}
 
   @impl Juvet.Router
-  def request_format(_context), do: {:error, :unknown_platform}
+  def request_format(_request), do: {:error, :unknown_platform}
 
   @impl Juvet.Router
   def validate(_platform), do: {:error, :unknown_platform}

--- a/test/juvet/controller_test.exs
+++ b/test/juvet/controller_test.exs
@@ -7,6 +7,8 @@ defmodule Juvet.ControllerTest do
   defmodule Controllers.MyController do
     use Juvet.Controller
 
+    def request_format_test(context), do: request_format(context)
+
     def send_message_test(context, template, assigns \\ []) do
       context
       |> put_view(MyView)
@@ -51,6 +53,20 @@ defmodule Juvet.ControllerTest do
   end
 
   describe "request_format/1" do
+    test "returns :modal if the request is from a Slack message" do
+      payload = %{
+        "view" => %{"id" => "V12345"},
+        "container" => %{"type" => "view"}
+      }
+
+      request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
+      context = %{request: request}
+
+      assert MyController.request_format_test(context) == :modal
+    end
+  end
+
+  describe "request_format_from/1" do
     test "returns :message if the request is from a Slack message" do
       payload = %{
         "message" => %{
@@ -60,9 +76,8 @@ defmodule Juvet.ControllerTest do
       }
 
       request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
-      context = %{request: request}
 
-      assert Juvet.Controller.request_format(context) == :message
+      assert Juvet.Controller.request_format_from(request) == :message
     end
   end
 

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -59,9 +59,8 @@ defmodule Juvet.Router.SlackRouterTest do
       }
 
       request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
-      context = %{request: request}
 
-      assert SlackRouter.request_format(context) == {:ok, :message}
+      assert SlackRouter.request_format(request) == {:ok, :message}
     end
 
     test "returns :modal when the payload has a modal request" do
@@ -71,9 +70,8 @@ defmodule Juvet.Router.SlackRouterTest do
       }
 
       request = %Request{platform: :slack, raw_params: %{"payload" => payload}}
-      context = %{request: request}
 
-      assert SlackRouter.request_format(context) == {:ok, :modal}
+      assert SlackRouter.request_format(request) == {:ok, :modal}
     end
 
     test "returns :page when the params has a home tab request" do
@@ -82,9 +80,8 @@ defmodule Juvet.Router.SlackRouterTest do
       }
 
       request = %Request{platform: :slack, raw_params: raw_params}
-      context = %{request: request}
 
-      assert SlackRouter.request_format(context) == {:ok, :page}
+      assert SlackRouter.request_format(request) == {:ok, :page}
     end
 
     test "returns :none when the params has any other event request" do
@@ -93,9 +90,8 @@ defmodule Juvet.Router.SlackRouterTest do
       }
 
       request = %Request{platform: :slack, raw_params: raw_params}
-      context = %{request: request}
 
-      assert SlackRouter.request_format(context) == {:ok, :none}
+      assert SlackRouter.request_format(request) == {:ok, :none}
     end
   end
 end


### PR DESCRIPTION
Use the imported `request_format/1` function and rename the local function.

NOTE: This is not the correct way to "architect" this. Just have to import all the functions. Or make an `Internal` module if there are some functions to hide.
