### PR TITLE
Fixes issue with route runner getting into an infinate loop

### DIFF
--- a/lib/juvet/middleware/action_generator.ex
+++ b/lib/juvet/middleware/action_generator.ex
@@ -5,7 +5,7 @@ defmodule Juvet.Middleware.ActionGenerator do
   """
   @spec call(map()) :: {:ok, map()} | {:error, any()}
   def call(%{path: path} = context) do
-    {:ok, Map.put_new(context, :action, generate_action(path))}
+    {:ok, Map.put(context, :action, generate_action(path))}
   end
 
   def call(_context), do: path_missing()

--- a/lib/juvet/runner.ex
+++ b/lib/juvet/runner.ex
@@ -18,6 +18,7 @@ defmodule Juvet.Runner do
     default_configuration(configuration)
     |> Map.merge(%{path: path})
     |> Map.merge(context)
+    |> Map.delete(:conn)
     |> merge_middleware()
     |> MiddlewareProcessor.process()
   end

--- a/lib/juvet/runner.ex
+++ b/lib/juvet/runner.ex
@@ -16,9 +16,9 @@ defmodule Juvet.Runner do
     {configuration, context} = Map.pop(context, :configuration)
 
     default_configuration(configuration)
-    |> Map.merge(%{path: path})
     |> Map.merge(context)
     |> Map.delete(:conn)
+    |> Map.merge(%{path: path})
     |> merge_middleware()
     |> MiddlewareProcessor.process()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.5.3",
+      version: "0.5.4",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/middleware/action_generator_test.exs
+++ b/test/juvet/middleware/action_generator_test.exs
@@ -24,6 +24,18 @@ defmodule Juvet.Middleware.ActionGeneratorTest do
       assert ctx[:action] == {:"Elixir.TestController", :action}
     end
 
+    test "overrides an existing action",
+         %{
+           context: context
+         } do
+      assert {:ok, ctx} =
+               ActionGenerator.call(
+                 Map.merge(context, %{action: {:BlahController, :other_action}})
+               )
+
+      assert ctx[:action] == {:"Elixir.TestController", :action}
+    end
+
     test "handle namespacing in the controller path" do
       assert {:ok, context} =
                ActionGenerator.call(%{

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -58,6 +58,12 @@ defmodule Juvet.RunnerTest do
                {:"Elixir.Juvet.RunnerTest.TestController", :action}
     end
 
+    test "removes the conn from the context", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path, %{conn: %Plug.Conn{}})
+
+      refute Map.has_key?(context, :conn)
+    end
+
     test "calls the controller module and action from the path", %{path: path} do
       {:ok, _context} =
         Juvet.Runner.route(path, %{pid: self(), configuration: [router: MyRouter]})

--- a/test/juvet/runner_test.exs
+++ b/test/juvet/runner_test.exs
@@ -51,6 +51,12 @@ defmodule Juvet.RunnerTest do
       assert Map.fetch!(context, :path) == path
     end
 
+    test "overrides the path if there is one in the context", %{path: path} do
+      {:ok, context} = Juvet.Runner.route(path, %{path: "juvet.runner_test_two.test#some_action"})
+
+      assert Map.fetch!(context, :path) == path
+    end
+
     test "adds the route to the context based on the path", %{path: path} do
       {:ok, context} = Juvet.Runner.route(path, %{configuration: [router: MyRouter]})
 


### PR DESCRIPTION
This PR fixes an issue when calling `Juvet.route` with a current context that has a current connection.

This caused an infinate loop for 3 reasons:

1. The context had a `conn` key, which means the partial middleware was not retrieved
1. The context did not override the calculated `action` from the `ActionGenerator`
1. The context overrode the `path` passed in with what was already in the context

All of these issues were fixed in this PR.
