### PR TITLE
Fix OAuth Cancel

### DIFF
--- a/lib/juvet/router/slack_route_handler.ex
+++ b/lib/juvet/router/slack_route_handler.ex
@@ -43,6 +43,20 @@ defmodule Juvet.Router.SlackRouteHandler do
     end
   end
 
+  def handle_route(
+        %{
+          route: %{type: :oauth, route: "callback"},
+          request: %{
+            raw_params: %{"error" => error, "error_description" => error_description}
+          }
+        } = context
+      ) do
+    context
+    |> Map.put(:error, error)
+    |> Map.put(:error_description, error_description)
+    |> route_oauth_or_error("error")
+  end
+
   defp route_oauth_or_error(
          %{configuration: configuration, request: %{platform: platform}} = context,
          route

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/integration/slack_oauth_test.exs
+++ b/test/juvet/integration/slack_oauth_test.exs
@@ -142,4 +142,35 @@ defmodule Juvet.Integration.SlackOauthTest do
       end
     end
   end
+
+  describe "with a Slack OAuth cancel authorization" do
+    test "it is routed correctly" do
+      conn =
+        request!(
+          :get,
+          "/auth/slack/callback",
+          %{"error" => "access_denied", "error_description" => "The user denied your request"},
+          [{"accept", "text/html"}],
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [
+              oauth_callback_endpoint: "/auth/slack/callback",
+              oauth_request_endpoint: "/auth/slack",
+              app_id: "APP_ID",
+              client_id: "CLIENT_ID",
+              client_secret: "CLIENT_SECRET",
+              redirect_uri: "REDIRECT_URI",
+              scope: "SCOPE",
+              user_scope: "USER_SCOPE"
+            ]
+          ]
+        )
+
+      assert conn.status == 200
+      assert conn.halted
+
+      assert_received :called_error_action
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an issue found with the OAuth integration with #88.

The issue is that Juvet did not handle the cancel route for an oauth callback. This did not route correctly because there was no code provided.

A new route handler was added which will pattern match on parameters with an error.
