### PR TITLE
Fix Issues with the Slack ViewState Parser

### DIFF
--- a/lib/juvet/slack_view_state.ex
+++ b/lib/juvet/slack_view_state.ex
@@ -7,15 +7,20 @@ defmodule Juvet.SlackViewState do
   def parse(view_state) do
     view_state
     |> Enum.reduce(%{}, fn {_block_id, block}, form ->
-      [{action_id, action}] = block |> Map.to_list()
-      Map.merge(form, action_value(action_id, action))
+      block
+      |> Map.to_list()
+      |> Enum.reduce(form, fn {action_id, action}, reduced_form ->
+        Map.merge(reduced_form, action_value(action_id, action))
+      end)
     end)
   end
 
   defp action_value(action_id, action), do: %{action_id => form_value(action)}
 
   defp form_value(%{"selected_conversation" => value}), do: value
+  defp form_value(%{"selected_date" => value}), do: value
   defp form_value(%{"selected_option" => %{"value" => value}}), do: value
+  defp form_value(%{"selected_time" => value}), do: value
 
   defp form_value(%{"selected_options" => options}) do
     Enum.map(options, fn %{"value" => value} -> value end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Juvet.Mixfile do
   def project do
     [
       app: :juvet,
-      version: "0.6.1",
+      version: "0.6.2",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Juvet",

--- a/test/juvet/slack_view_state_test.exs
+++ b/test/juvet/slack_view_state_test.exs
@@ -69,5 +69,31 @@ defmodule Juvet.SlackViewStateTest do
                "checkboxes_field" => ["selected_value"]
              }
     end
+
+    test "handles multiple fields under one block" do
+      view_state = %{
+        "block_id_1" => %{
+          "field1" => %{
+            "selected_option" => %{
+              "text" => %{
+                "type" => "plain_text",
+                "text" => "Selected value"
+              },
+              "value" => "selected_value"
+            },
+            "type" => "static_select"
+          },
+          "field2" => %{
+            "selected_date" => "2020-01-04",
+            "type" => "datepicker"
+          }
+        }
+      }
+
+      assert SlackViewState.parse(view_state) == %{
+               "field1" => "selected_value",
+               "field2" => "2020-01-04"
+             }
+    end
   end
 end


### PR DESCRIPTION
The `SlackViewState` module was updated so it can handle multiple fields under a block. This can occur when you have a view_submission with a datepicker and a timepicker in actions.

In addition, it also handles returning the values for Slack's `datepicker` and `timepicker`
