### PR TITLE
users.list endpoint

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.0.4
+erlang 26.1
 elixir 1.14.1

--- a/lib/juvet/slack_api/endpoint.ex
+++ b/lib/juvet/slack_api/endpoint.ex
@@ -1,0 +1,24 @@
+defmodule Juvet.SlackAPI.Endpoint do
+  alias Juvet.SlackAPI
+
+  def request_and_render(method, options) do
+    options = options |> transform_options
+
+    SlackAPI.make_request(method, options)
+    |> SlackAPI.render_response()
+  end
+
+  defp transform_options(options) do
+    options
+    |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
+    |> Enum.into(%{})
+  end
+
+  defmacro __using__(_) do
+    quote do
+      alias Juvet.SlackAPI
+
+      import Juvet.SlackAPI.Endpoint
+    end
+  end
+end

--- a/lib/juvet/slack_api/reactions.ex
+++ b/lib/juvet/slack_api/reactions.ex
@@ -3,7 +3,7 @@ defmodule Juvet.SlackAPI.Reactions do
   A wrapper around the reactions methods on the Slack API.
   """
 
-  alias Juvet.SlackAPI
+  use Juvet.SlackAPI.Endpoint
 
   @doc """
   Adds a reaction to an item.
@@ -77,17 +77,4 @@ defmodule Juvet.SlackAPI.Reactions do
   """
   @spec remove(map()) :: {:ok, map()} | {:error, map()}
   def remove(options \\ %{}), do: request_and_render("reactions.remove", options)
-
-  defp request_and_render(method, options) do
-    options = options |> transform_options
-
-    SlackAPI.make_request(method, options)
-    |> SlackAPI.render_response()
-  end
-
-  defp transform_options(options) do
-    options
-    |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
-    |> Enum.into(%{})
-  end
 end

--- a/lib/juvet/slack_api/rtm.ex
+++ b/lib/juvet/slack_api/rtm.ex
@@ -3,7 +3,7 @@ defmodule Juvet.SlackAPI.RTM do
   A wrapper around the rtm methods on the Slack API.
   """
 
-  alias Juvet.SlackAPI
+  use Juvet.SlackAPI.Endpoint
 
   @doc """
   Requests a new connection via websockets for the Slack API
@@ -28,8 +28,5 @@ defmodule Juvet.SlackAPI.RTM do
   } = Juvet.Connection.SlackRTM.connect(%{token: token})
   """
   @spec connect(map()) :: {:ok, map()} | {:error, map()}
-  def connect(options \\ %{}) do
-    SlackAPI.make_request("rtm.connect", options)
-    |> SlackAPI.render_response()
-  end
+  def connect(options \\ %{}), do: request_and_render("rtm.connect", options)
 end

--- a/lib/juvet/slack_api/teams.ex
+++ b/lib/juvet/slack_api/teams.ex
@@ -3,7 +3,7 @@ defmodule Juvet.SlackAPI.Teams do
   A wrapper around the team methods on the Slack API.
   """
 
-  alias Juvet.SlackAPI
+  use Juvet.SlackAPI.Endpoint
 
   @doc """
   Requests information on a specific team.
@@ -21,8 +21,5 @@ defmodule Juvet.SlackAPI.Teams do
   """
 
   @spec info(map()) :: {:ok, map()} | {:error, map()}
-  def info(options \\ %{}) do
-    SlackAPI.make_request("team.info", options)
-    |> SlackAPI.render_response()
-  end
+  def info(options \\ %{}), do: request_and_render("team.info", options)
 end

--- a/lib/juvet/slack_api/users.ex
+++ b/lib/juvet/slack_api/users.ex
@@ -21,10 +21,7 @@ defmodule Juvet.SlackAPI.Users do
   """
 
   @spec info(map()) :: {:ok, map()} | {:error, map()}
-  def info(options \\ %{}) do
-    SlackAPI.make_request("users.info", options)
-    |> SlackAPI.render_response()
-  end
+  def info(options \\ %{}), do: request_and_render("users.info", options)
 
   @doc """
   Lists all users on a team.

--- a/lib/juvet/slack_api/users.ex
+++ b/lib/juvet/slack_api/users.ex
@@ -3,7 +3,7 @@ defmodule Juvet.SlackAPI.Users do
   A wrapper around the users methods on the Slack API.
   """
 
-  alias Juvet.SlackAPI
+  use Juvet.SlackAPI.Endpoint
 
   @doc """
   Requests information on a specific user.
@@ -25,4 +25,27 @@ defmodule Juvet.SlackAPI.Users do
     SlackAPI.make_request("users.info", options)
     |> SlackAPI.render_response()
   end
+
+  @doc """
+  Lists all users on a team.
+
+  Returns a map of the Slack response.
+
+  ## Example
+
+  %{
+    ok: true,
+    members: [
+      %{
+        id: "U1234",
+        team_id: "T12345",
+        deleted: false,
+        name: "Jimmy Page",
+        profile: %{}
+      }
+    ]
+  } = Juvet.SlackAPI.Ysers.list(%{token: token, limit: 20})
+  """
+  @spec list(map()) :: {:ok, map()} | {:error, map()}
+  def list(options \\ %{}), do: request_and_render("users.list", options)
 end


### PR DESCRIPTION
This PR adds the endpoint to the `SlackAPI.Users` module for the `list` action endpoint.

In addition, this starts a common module that can be composed in to provide common functionality within all endpoints. This updates some of those endpoints.

Some of the endpoints were replaced with the new module. However, several modules have special transformations. This will be fixed in a subsequent PR. The hole has been plugged.
