### PR TITLE
Fix builder_opts depreciation

### DIFF
--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -32,7 +32,7 @@ defmodule Juvet.Plug do
 
   plug(:dispatch)
 
-  match(_, do: conn)
+  match(_, to: Juvet.SlackRoute)
 
   defp insert_juvet_options(conn, opts), do: Conn.put_private(conn, %{options: opts})
 end

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -6,7 +6,7 @@ defmodule Juvet.Plug do
   resort to return a 404.
   """
 
-  use Plug.Router
+  use Plug.Router, copy_opts_to_assign: :builder_opts
   use Juvet.SlackRoutes
 
   alias Juvet.Router.Conn
@@ -20,7 +20,7 @@ defmodule Juvet.Plug do
   end
 
   unless Mix.env() == :test, do: plug(Plug.Logger)
-  plug(:insert_juvet_options, builder_opts())
+  plug(:insert_juvet_options)
   plug(:match)
 
   plug(Plug.Parsers,
@@ -34,5 +34,6 @@ defmodule Juvet.Plug do
 
   match(_, to: Juvet.SlackRoute)
 
-  defp insert_juvet_options(conn, opts), do: Conn.put_private(conn, %{options: opts})
+  defp insert_juvet_options(conn, _),
+    do: Conn.put_private(conn, %{options: conn.assigns.builder_opts})
 end

--- a/lib/juvet/plug.ex
+++ b/lib/juvet/plug.ex
@@ -32,7 +32,7 @@ defmodule Juvet.Plug do
 
   plug(:dispatch)
 
-  match(_, to: Juvet.SlackRoute)
+  match(_, do: conn)
 
   defp insert_juvet_options(conn, _),
     do: Conn.put_private(conn, %{options: conn.assigns.builder_opts})

--- a/test/juvet/plug_test.exs
+++ b/test/juvet/plug_test.exs
@@ -33,7 +33,6 @@ defmodule Juvet.PlugTest do
   end
 
   describe "GET /slack/blah" do
-    @tag skip: "skipping this test for now as all of the reqests are being sent"
     test "returns the conn without sending a response" do
       conn = request!(:post, "/slack/blah", nil, nil, configuration: [router: MyRouter])
 

--- a/test/juvet/plug_test.exs
+++ b/test/juvet/plug_test.exs
@@ -33,6 +33,7 @@ defmodule Juvet.PlugTest do
   end
 
   describe "GET /slack/blah" do
+    @tag skip: "skipping this test for now as all of the reqests are being sent"
     test "returns the conn without sending a response" do
       conn = request!(:post, "/slack/blah", nil, nil, configuration: [router: MyRouter])
 

--- a/test/support/fake_slack.ex
+++ b/test/support/fake_slack.ex
@@ -5,7 +5,7 @@ defmodule Juvet.FakeSlack do
   """
 
   alias Juvet.FakeSlack.Websocket
-  alias Plug.Adapters.Cowboy
+  alias Plug.Cowboy
 
   def start_link(url \\ "http://localhost:51345") do
     # This is used by the application config so it can be pluggable


### PR DESCRIPTION
This PR fixes a warning for [`builder_opts` depreciation](https://hexdocs.pm/plug/Plug.Builder.html#builder_opts/0).
