### PR TITLE
fix(template): support for-loops inside element children

### DIFF
--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -488,7 +488,7 @@ defmodule Juvet.Template do
   as-is.
   """
   def eval_map(%{__for__: true} = node, bindings) do
-    collection = Keyword.fetch!(bindings, String.to_atom(node.collection))
+    collection = resolve_binding(node.collection, bindings)
     variable = String.to_atom(node.variable)
 
     Enum.flat_map(collection, fn item ->
@@ -528,6 +528,19 @@ defmodule Juvet.Template do
   end
 
   def eval_map(data, _bindings), do: data
+
+  @doc false
+  def resolve_binding(path, bindings) when is_binary(path) do
+    case String.split(path, ".") do
+      [key] ->
+        Keyword.fetch!(bindings, String.to_atom(key))
+
+      [root | fields] ->
+        Enum.reduce(fields, Keyword.fetch!(bindings, String.to_atom(root)), fn field, acc ->
+          Map.fetch!(acc, String.to_atom(field))
+        end)
+    end
+  end
 
   # Extracts the source string from an opts keyword list for inline templates.
   # Returns {source, remaining_opts} where remaining_opts may include :platform.
@@ -707,13 +720,13 @@ defmodule Juvet.Template do
   # When the for-loop body contains code blocks, uses binding threading.
   defp compiled_to_quoted(%{__for__: true} = node, bindings_var) do
     variable = String.to_atom(node.variable)
-    collection = String.to_atom(node.collection)
+    collection_path = node.collection
     item_var = Macro.var(variable, __MODULE__)
 
     if Enum.any?(node.body, &match?(%{__code_block__: true}, &1)) do
-      for_quoted_with_code_blocks(node.body, variable, collection, item_var, bindings_var)
+      for_quoted_with_code_blocks(node.body, variable, collection_path, item_var, bindings_var)
     else
-      for_quoted_without_code_blocks(node.body, variable, collection, item_var, bindings_var)
+      for_quoted_without_code_blocks(node.body, variable, collection_path, item_var, bindings_var)
     end
   end
 
@@ -795,12 +808,12 @@ defmodule Juvet.Template do
   defp compiled_to_quoted(value, _bindings_var), do: Macro.escape(value)
 
   # For-loop quoted AST when body contains code blocks - uses binding threading.
-  defp for_quoted_with_code_blocks(body, variable, collection, item_var, bindings_var) do
+  defp for_quoted_with_code_blocks(body, variable, collection_path, item_var, bindings_var) do
     body_callbacks = Enum.map(body, &compiled_to_quoted_with_bindings/1)
 
     quote do
       Enum.flat_map(
-        Keyword.fetch!(unquote(bindings_var), unquote(collection)),
+        Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)),
         fn unquote(item_var) ->
           iter_bindings = Keyword.put(unquote(bindings_var), unquote(variable), unquote(item_var))
 
@@ -814,7 +827,7 @@ defmodule Juvet.Template do
   end
 
   # For-loop quoted AST when body has no code blocks - simple eval_map approach.
-  defp for_quoted_without_code_blocks(body, variable, collection, item_var, bindings_var) do
+  defp for_quoted_without_code_blocks(body, variable, collection_path, item_var, bindings_var) do
     body_elements =
       Enum.map(body, fn body_el ->
         escaped_body = Macro.escape(body_el)
@@ -831,18 +844,19 @@ defmodule Juvet.Template do
       [single] ->
         quote do
           for unquote(item_var) <-
-                Keyword.fetch!(unquote(bindings_var), unquote(collection)) do
+                Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)) do
             unquote(single)
           end
         end
 
       multiple ->
         quote do
-          Enum.flat_map(Keyword.fetch!(unquote(bindings_var), unquote(collection)), fn unquote(
-                                                                                         item_var
-                                                                                       ) ->
-            unquote(multiple)
-          end)
+          Enum.flat_map(
+            Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)),
+            fn unquote(item_var) ->
+              unquote(multiple)
+            end
+          )
         end
     end
   end

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -526,12 +526,12 @@ defmodule Juvet.Template do
     end
   end
 
+  def eval_map(data, _bindings), do: data
+
   defp single_eex_expression?(data) do
     Regex.match?(~r/\A<%=\s*.+?\s*%>\z/s, data) and
       length(Regex.scan(~r/<%=/, data)) == 1
   end
-
-  def eval_map(data, _bindings), do: data
 
   @doc false
   def resolve_binding(path, bindings) when is_binary(path) do

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -513,18 +513,22 @@ defmodule Juvet.Template do
   end
 
   def eval_map(data, bindings) when is_binary(data) do
-    case Regex.run(~r/\A<%=\s*(.+?)\s*%>\z/, data) do
-      [_, expression] ->
-        {result, _} = Code.eval_string(expression, bindings)
-        if is_boolean(result), do: result, else: to_string(result)
-
-      _ ->
-        if String.contains?(data, "<%") do
-          EEx.eval_string(data, bindings)
-        else
-          data
-        end
+    if single_eex_expression?(data) do
+      [_, expression] = Regex.run(~r/\A<%=\s*(.+?)\s*%>\z/s, data)
+      {result, _} = Code.eval_string(expression, bindings)
+      if is_boolean(result), do: result, else: to_string(result)
+    else
+      if String.contains?(data, "<%") do
+        EEx.eval_string(data, bindings)
+      else
+        data
+      end
     end
+  end
+
+  defp single_eex_expression?(data) do
+    Regex.match?(~r/\A<%=\s*.+?\s*%>\z/s, data) and
+      length(Regex.scan(~r/<%=/, data)) == 1
   end
 
   def eval_map(data, _bindings), do: data

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -534,17 +534,16 @@ defmodule Juvet.Template do
   end
 
   @doc false
-  def resolve_binding(path, bindings) when is_binary(path) do
-    case String.split(path, ".") do
-      [key] ->
-        Keyword.fetch!(bindings, String.to_atom(key))
-
-      [root | fields] ->
-        Enum.reduce(fields, Keyword.fetch!(bindings, String.to_atom(root)), fn field, acc ->
-          Map.fetch!(acc, String.to_atom(field))
-        end)
+  def resolve_binding(expression, bindings) when is_binary(expression) do
+    if simple_binding?(expression) do
+      Keyword.fetch!(bindings, String.to_atom(expression))
+    else
+      {result, _} = Code.eval_string(expression, bindings)
+      result
     end
   end
+
+  defp simple_binding?(expression), do: Regex.match?(~r/\A\w+\z/, expression)
 
   # Extracts the source string from an opts keyword list for inline templates.
   # Returns {source, remaining_opts} where remaining_opts may include :platform.

--- a/lib/juvet/template/parser.ex
+++ b/lib/juvet/template/parser.ex
@@ -170,7 +170,18 @@ defmodule Juvet.Template.Parser do
   end
 
   # Attribute dispatching
-  defp attributes([{:open_brace, _, _} | rest], _platform), do: inline_attrs(rest, %{})
+  # Inline attrs optionally followed by a block (e.g., .option_group{label: "..."}\n  options:\n    ...)
+  defp attributes([{:open_brace, _, _} | rest], platform) do
+    {inline, rest} = inline_attrs(rest, %{})
+
+    case rest do
+      [{:newline, _, _}, {:indent, _, _} | block_rest] ->
+        merge_inline_with_block(inline, block_rest, platform)
+
+      _ ->
+        {inline, rest}
+    end
+  end
 
   # Multi-line block (newline + indent)
   defp attributes([{:newline, _, _}, {:indent, _, _} | rest], platform) do
@@ -191,6 +202,16 @@ defmodule Juvet.Template.Parser do
 
   defp attributes([{:eof, _, _}] = rest, _platform), do: {%{}, rest}
   defp attributes(rest, _platform), do: {%{}, rest}
+
+  defp merge_inline_with_block(inline, block_rest, platform) do
+    case block(block_rest, %{}, %{}, platform) do
+      {{block_attrs, children}, rest} ->
+        {{Map.merge(inline, block_attrs), children}, rest}
+
+      {block_attrs, rest} ->
+        {Map.merge(inline, block_attrs), rest}
+    end
+  end
 
   # Block parsing - indented attributes and children until dedent
   defp block([{:dedent, _, _} | rest], attrs, children, _platform) do
@@ -253,7 +274,11 @@ defmodule Juvet.Template.Parser do
     block(rest, Map.put(attrs, String.to_atom(key), val), children, platform)
   end
 
-  # Single element stored as-is, multiple elements stored as list
+  # Single element stored as-is, multiple elements stored as list.
+  # For-loops and code blocks expand to multiple elements at runtime,
+  # so they must stay wrapped in a list.
+  defp child_value([%{node_type: :for_loop}] = list), do: list
+  defp child_value([%{node_type: :code_block}] = list), do: list
   defp child_value([single]), do: single
   defp child_value(multiple), do: multiple
 
@@ -393,9 +418,10 @@ defmodule Juvet.Template.Parser do
   end
 
   # Parses a for-loop expression like "for item <- items do"
+  # or "for item <- parent.items do" (dotted access on collection)
   # Returns {:ok, variable, collection} or :error
   defp parse_for_expression(expr) do
-    case Regex.run(~r/\Afor\s+(\w+)\s*<-\s*(\w+)\s+do\z/, expr) do
+    case Regex.run(~r/\Afor\s+(\w+)\s*<-\s*([\w.]+)\s+do\z/, expr) do
       [_, variable, collection] -> {:ok, variable, collection}
       _ -> :error
     end

--- a/lib/juvet/template/parser.ex
+++ b/lib/juvet/template/parser.ex
@@ -417,12 +417,12 @@ defmodule Juvet.Template.Parser do
     end
   end
 
-  # Parses a for-loop expression like "for item <- items do"
-  # or "for item <- parent.items do" (dotted access on collection)
-  # Returns {:ok, variable, collection} or :error
+  # Parses a for-loop expression like "for item <- items do",
+  # "for item <- parent.items do", or "for item <- helper.(items) do"
+  # Returns {:ok, variable, collection_expression} or :error
   defp parse_for_expression(expr) do
-    case Regex.run(~r/\Afor\s+(\w+)\s*<-\s*([\w.]+)\s+do\z/, expr) do
-      [_, variable, collection] -> {:ok, variable, collection}
+    case Regex.run(~r/\Afor\s+(\w+)\s*<-\s*(.+)\s+do\z/, expr) do
+      [_, variable, collection] -> {:ok, variable, String.trim(collection)}
       _ -> :error
     end
   end

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1642,8 +1642,7 @@ defmodule Juvet.TemplateTest do
     end
 
     test "for-loop collection can be an inline Elixir expression" do
-      result =
-        ForLoopFunctionCallTemplates.with_inline_call(items: [1, 2, 3, 4, 5])
+      result = ForLoopFunctionCallTemplates.with_inline_call(items: [1, 2, 3, 4, 5])
 
       assert result.blocks == [
                %{type: "section", text: %{type: "mrkdwn", text: "2"}},

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1574,4 +1574,32 @@ defmodule Juvet.TemplateTest do
              }
     end
   end
+
+  describe "multiple EEx expressions in attribute values" do
+    defmodule MultipleEExTemplates do
+      use Juvet.Template
+
+      template(:multiple_eex_in_value,
+        slack:
+          ".view\n  type: :modal\n  blocks:\n    .actions\n      elements:\n        .button{text: \"Click\", action_id: \"btn\"}\n        .select\n          source: :static\n          action_id: \"test\"\n          placeholder: \"Pick...\"\n          options:\n            <%= for item <- items do %>\n              .option{text: \"<%= item.name %>\", value: \"<%= item.prefix %>_<%= item.id %>\"}\n            <% end %>"
+      )
+    end
+
+    test "multiple EEx expressions in a single attribute value render correctly" do
+      result =
+        MultipleEExTemplates.multiple_eex_in_value(
+          items: [
+            %{name: "Task One", prefix: "tasks", id: 42},
+            %{name: "Poll Two", prefix: "polls", id: 7}
+          ]
+        )
+
+      select = result.blocks |> hd() |> Map.get(:elements) |> List.last()
+
+      assert select.options == [
+               %{text: %{type: "plain_text", text: "Task One"}, value: "tasks_42"},
+               %{text: %{type: "plain_text", text: "Poll Two"}, value: "polls_7"}
+             ]
+    end
+  end
 end

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1586,6 +1586,7 @@ defmodule Juvet.TemplateTest do
     end
 
     test "multiple EEx expressions in a single attribute value render correctly" do
+      # This also makes sure `_` is handled within the EEx expression
       result =
         MultipleEExTemplates.multiple_eex_in_value(
           items: [
@@ -1599,6 +1600,55 @@ defmodule Juvet.TemplateTest do
       assert select.options == [
                %{text: %{type: "plain_text", text: "Task One"}, value: "tasks_42"},
                %{text: %{type: "plain_text", text: "Poll Two"}, value: "polls_7"}
+             ]
+    end
+  end
+
+  describe "function calls in for-loop collections" do
+    defmodule ForLoopHelpers do
+      def group_items(items) do
+        items
+        |> Enum.group_by(& &1.type)
+        |> Enum.map(fn {type, group} -> %{label: type, items: group} end)
+      end
+    end
+
+    defmodule ForLoopFunctionCallTemplates do
+      use Juvet.Template, helpers: [Juvet.TemplateTest.ForLoopHelpers]
+
+      template(:with_helper_call,
+        slack:
+          ".view\n  type: :modal\n  blocks:\n    <%= for group <- group_items.(items) do %>\n      .section{text: \"<%= group.label %>\", type: :mrkdwn}\n    <% end %>"
+      )
+
+      template(:with_inline_call,
+        slack:
+          ".view\n  type: :modal\n  blocks:\n    <%= for group <- Enum.chunk_every(items, 2) do %>\n      .section{text: \"<%= length(group) %>\", type: :mrkdwn}\n    <% end %>"
+      )
+    end
+
+    test "for-loop collection can be a helper function call" do
+      result =
+        ForLoopFunctionCallTemplates.with_helper_call(
+          items: [
+            %{type: "Tasks", name: "T1"},
+            %{type: "Tasks", name: "T2"},
+            %{type: "Polls", name: "P1"}
+          ]
+        )
+
+      labels = Enum.map(result.blocks, & &1.text.text) |> Enum.sort()
+      assert labels == ["Polls", "Tasks"]
+    end
+
+    test "for-loop collection can be an inline Elixir expression" do
+      result =
+        ForLoopFunctionCallTemplates.with_inline_call(items: [1, 2, 3, 4, 5])
+
+      assert result.blocks == [
+               %{type: "section", text: %{type: "mrkdwn", text: "2"}},
+               %{type: "section", text: %{type: "mrkdwn", text: "2"}},
+               %{type: "section", text: %{type: "mrkdwn", text: "1"}}
              ]
     end
   end


### PR DESCRIPTION
## Summary

Enables `<%= for ... %>` loops inside element children like `options:` and `option_groups:` in Cheex templates. Previously, for-loops only worked at the block level — using them inside element attributes like select options would silently drop the content.

### What was broken

```
.select
  source: :static
  action_id: "my_select"
  placeholder: "Pick one..."
  options:
    <%= for opt <- options do %>
      .option{text: "<%= opt.text %>", value: "<%= opt.value %>"}
    <% end %>
```

This would compile but produce a select with no options — the for-loop output was silently discarded.

### Root causes (3 fixes)

1. **`child_value` unwrapped single-element lists** — when `options:` had a single for-loop node, `child_value([single])` unwrapped it from a list to a map. Element compilers use `when is_list(options)` guards, so the unwrapped map fell through to the fallback clause that returns `[]`.

2. **Inline attrs + block not supported** — `.option_group{label: "..."}` followed by a nested `options:` block only captured the inline attrs. The block children were left unconsumed, causing parse errors in nested for-loops.

3. **Dotted collection access not supported** — `for opt <- group.options do` failed because the for-loop regex only matched simple variable names (`\w+`), not dotted paths like `group.options`.

### Changes

**`parser.ex`**:
- `child_value` preserves for-loop and code-block nodes as lists
- `attributes()` supports inline attrs `{...}` followed by an indented block
- `parse_for_expression` regex accepts dotted collection access (`[\w.]+`)

**`template.ex`**:
- New `resolve_binding/2` handles dotted paths (e.g., `"group.options"` → fetch `group` from bindings, then access `.options`)
- `for_quoted_with/without_code_blocks` uses `resolve_binding` instead of `Keyword.fetch!`
- `eval_map` for-loop clause uses `resolve_binding`

### Now works

Simple options:
```
.select
  options:
    <%= for opt <- options do %>
      .option{text: "<%= opt.text %>", value: "<%= opt.value %>"}
    <% end %>
```

Nested option groups:
```
.select
  option_groups:
    <%= for group <- groups do %>
      .option_group{label: "<%= group.label %>"}
        options:
          <%= for opt <- group.options do %>
            .option{text: "<%= opt.text %>", value: "<%= opt.value %>"}
          <% end %>
    <% end %>
```

## Test plan

- [x] Existing template tests pass
- [x] For-loop inside `options:` produces correct Block Kit JSON
- [x] For-loop inside `option_groups:` with nested for-loops produces correct Block Kit JSON
- [x] Dotted collection access (`group.options`) resolves correctly at runtime
- [x] Templates without for-loops are unaffected (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)