### PR TITLE
feat: Add missing attributes to button compiler

### DIFF
--- a/lib/juvet/template/compiler/slack/elements/button.ex
+++ b/lib/juvet/template/compiler/slack/elements/button.ex
@@ -11,12 +11,14 @@ defmodule Juvet.Template.Compiler.Slack.Elements.Button do
       text: Text.compile(text_attrs.text, Map.put_new(text_attrs, :type, :plain_text))
     }
     |> maybe_put(:action_id, attrs[:action_id])
+    |> maybe_put(:value, attrs[:value])
     |> maybe_put(:confirm, compile_confirm(el))
   end
 
   def compile(%{element: :button, attributes: %{text: text} = attrs} = el) do
     %{type: "button", text: Text.compile(text, Map.put_new(attrs, :type, :plain_text))}
     |> maybe_put(:action_id, attrs[:action_id])
+    |> maybe_put(:value, attrs[:value])
     |> maybe_put(:confirm, compile_confirm(el))
   end
 

--- a/lib/juvet/template/compiler/slack/elements/button.ex
+++ b/lib/juvet/template/compiler/slack/elements/button.ex
@@ -11,15 +11,21 @@ defmodule Juvet.Template.Compiler.Slack.Elements.Button do
       text: Text.compile(text_attrs.text, Map.put_new(text_attrs, :type, :plain_text))
     }
     |> maybe_put(:action_id, attrs[:action_id])
+    |> maybe_put(:url, attrs[:url])
     |> maybe_put(:value, attrs[:value])
+    |> maybe_put(:style, attrs[:style])
     |> maybe_put(:confirm, compile_confirm(el))
+    |> maybe_put(:accessibility_label, attrs[:accessibility_label])
   end
 
   def compile(%{element: :button, attributes: %{text: text} = attrs} = el) do
     %{type: "button", text: Text.compile(text, Map.put_new(attrs, :type, :plain_text))}
     |> maybe_put(:action_id, attrs[:action_id])
+    |> maybe_put(:url, attrs[:url])
     |> maybe_put(:value, attrs[:value])
+    |> maybe_put(:style, attrs[:style])
     |> maybe_put(:confirm, compile_confirm(el))
+    |> maybe_put(:accessibility_label, attrs[:accessibility_label])
   end
 
   defp compile_confirm(%{children: %{confirm: confirm}}),

--- a/test/juvet/template/compiler/slack_test.exs
+++ b/test/juvet/template/compiler/slack_test.exs
@@ -251,6 +251,41 @@ defmodule Juvet.Template.Compiler.SlackTest do
                ])
     end
 
+    test "button with value attribute" do
+      ast =
+        view_ast([
+          %{
+            platform: :slack,
+            element: :actions,
+            attributes: %{},
+            children: %{
+              elements: [
+                %{
+                  platform: :slack,
+                  element: :button,
+                  attributes: %{text: "Next", action_id: "paginate", value: "page:2"}
+                }
+              ]
+            }
+          }
+        ])
+
+      assert Slack.compile(ast) ==
+               view_expected([
+                 %{
+                   type: "actions",
+                   elements: [
+                     %{
+                       type: "button",
+                       text: %{type: "plain_text", text: "Next"},
+                       action_id: "paginate",
+                       value: "page:2"
+                     }
+                   ]
+                 }
+               ])
+    end
+
     test "actions with no elements returns empty array" do
       ast = view_ast([%{platform: :slack, element: :actions, attributes: %{}}])
 

--- a/test/juvet/template/compiler/slack_test.exs
+++ b/test/juvet/template/compiler/slack_test.exs
@@ -286,6 +286,115 @@ defmodule Juvet.Template.Compiler.SlackTest do
                ])
     end
 
+    test "button with style attribute" do
+      ast =
+        view_ast([
+          %{
+            platform: :slack,
+            element: :actions,
+            attributes: %{},
+            children: %{
+              elements: [
+                %{
+                  platform: :slack,
+                  element: :button,
+                  attributes: %{text: "Delete", action_id: "delete", style: "danger"}
+                }
+              ]
+            }
+          }
+        ])
+
+      assert Slack.compile(ast) ==
+               view_expected([
+                 %{
+                   type: "actions",
+                   elements: [
+                     %{
+                       type: "button",
+                       text: %{type: "plain_text", text: "Delete"},
+                       action_id: "delete",
+                       style: "danger"
+                     }
+                   ]
+                 }
+               ])
+    end
+
+    test "button with url attribute" do
+      ast =
+        view_ast([
+          %{
+            platform: :slack,
+            element: :actions,
+            attributes: %{},
+            children: %{
+              elements: [
+                %{
+                  platform: :slack,
+                  element: :button,
+                  attributes: %{text: "Open", action_id: "open", url: "https://example.com"}
+                }
+              ]
+            }
+          }
+        ])
+
+      assert Slack.compile(ast) ==
+               view_expected([
+                 %{
+                   type: "actions",
+                   elements: [
+                     %{
+                       type: "button",
+                       text: %{type: "plain_text", text: "Open"},
+                       action_id: "open",
+                       url: "https://example.com"
+                     }
+                   ]
+                 }
+               ])
+    end
+
+    test "button with accessibility_label attribute" do
+      ast =
+        view_ast([
+          %{
+            platform: :slack,
+            element: :actions,
+            attributes: %{},
+            children: %{
+              elements: [
+                %{
+                  platform: :slack,
+                  element: :button,
+                  attributes: %{
+                    text: "Save",
+                    action_id: "save",
+                    accessibility_label: "Save current changes"
+                  }
+                }
+              ]
+            }
+          }
+        ])
+
+      assert Slack.compile(ast) ==
+               view_expected([
+                 %{
+                   type: "actions",
+                   elements: [
+                     %{
+                       type: "button",
+                       text: %{type: "plain_text", text: "Save"},
+                       action_id: "save",
+                       accessibility_label: "Save current changes"
+                     }
+                   ]
+                 }
+               ])
+    end
+
     test "actions with no elements returns empty array" do
       ast = view_ast([%{platform: :slack, element: :actions, attributes: %{}}])
 


### PR DESCRIPTION
## Summary

- Adds all missing Slack Button Element attributes to the compiler
- Completes full API coverage per [Slack docs](https://docs.slack.dev/reference/block-kit/block-elements/button-element)

| Attribute | Status |
|-----------|--------|
| `type` | existing |
| `text` | existing |
| `action_id` | existing |
| `confirm` | existing |
| `value` | **new** |
| `url` | **new** |
| `style` | **new** |
| `accessibility_label` | **new** |

Follows the same `maybe_put` pattern used by `icon_button` and `feedback_buttons`.

## Test plan

- [x] New test: button with `value` attribute
- [x] New test: button with `style` attribute
- [x] New test: button with `url` attribute
- [x] New test: button with `accessibility_label` attribute
- [x] All 176 existing compiler tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)