### PR TITLE
fix(template): drop nil-valued attributes in eval_map

### DIFF
--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -498,7 +498,12 @@ defmodule Juvet.Template do
   end
 
   def eval_map(data, bindings) when is_map(data) do
-    Map.new(data, fn {k, v} -> {k, eval_map(v, bindings)} end)
+    Enum.reduce(data, %{}, fn {k, v}, acc ->
+      case eval_map(v, bindings) do
+        nil -> acc
+        evaluated -> Map.put(acc, k, evaluated)
+      end
+    end)
   end
 
   def eval_map(data, bindings) when is_list(data) do
@@ -516,7 +521,12 @@ defmodule Juvet.Template do
     if single_eex_expression?(data) do
       [_, expression] = Regex.run(~r/\A<%=\s*(.+?)\s*%>\z/s, data)
       {result, _} = Code.eval_string(expression, bindings)
-      if is_boolean(result), do: result, else: to_string(result)
+
+      cond do
+        is_nil(result) -> nil
+        is_boolean(result) -> result
+        true -> to_string(result)
+      end
     else
       if String.contains?(data, "<%") do
         EEx.eval_string(data, bindings)

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1651,4 +1651,77 @@ defmodule Juvet.TemplateTest do
              ]
     end
   end
+
+  describe "nil-valued attributes in single-EEx expressions" do
+    defmodule NilAttrTemplates do
+      use Juvet.Template
+
+      template(:datepicker_with_initial, """
+      :slack.view
+        type: :modal
+        blocks:
+          :slack.actions
+            elements:
+              :slack.datepicker{action_id: "pick", initial_date: <%= maybe_date %>}
+      """)
+
+      template(:datepicker_with_focus, """
+      :slack.view
+        type: :modal
+        blocks:
+          :slack.actions
+            elements:
+              :slack.datepicker{action_id: "pick", focus_on_load: <%= maybe_focus %>}
+      """)
+
+      template(:header_with_interpolation, """
+      :slack.view
+        type: :modal
+        blocks:
+          :slack.header{text: "Hello <%= name %>"}
+      """)
+    end
+
+    test "single-EEx attribute resolving to nil drops the key from the compiled map" do
+      result = NilAttrTemplates.datepicker_with_initial(maybe_date: nil)
+
+      [datepicker] = hd(result.blocks).elements
+      refute Map.has_key?(datepicker, :initial_date)
+    end
+
+    test "single-EEx attribute resolving to a real value keeps the key" do
+      result = NilAttrTemplates.datepicker_with_initial(maybe_date: "2026-06-01")
+
+      [datepicker] = hd(result.blocks).elements
+      assert datepicker.initial_date == "2026-06-01"
+    end
+
+    test "single-EEx boolean attribute resolving to nil drops the key" do
+      result = NilAttrTemplates.datepicker_with_focus(maybe_focus: nil)
+
+      [datepicker] = hd(result.blocks).elements
+      refute Map.has_key?(datepicker, :focus_on_load)
+    end
+
+    test "single-EEx boolean attribute resolving to true is preserved unchanged" do
+      result = NilAttrTemplates.datepicker_with_focus(maybe_focus: true)
+
+      [datepicker] = hd(result.blocks).elements
+      assert datepicker.focus_on_load == true
+    end
+
+    test "multi-token EEx interpolation with nil binding renders as empty string (unchanged)" do
+      result = NilAttrTemplates.header_with_interpolation(name: nil)
+
+      header = hd(result.blocks)
+      assert header.text.text == "Hello "
+    end
+
+    test "multi-token EEx interpolation with a real binding renders the interpolated text" do
+      result = NilAttrTemplates.header_with_interpolation(name: "World")
+
+      header = hd(result.blocks)
+      assert header.text.text == "Hello World"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- **PR 1 of 3** in the cheex modal-support effort &mdash; smallest, foundational fix.
- `eval_map/2` no longer stringifies a runtime-`nil` single-EEx expression to `""`; instead it preserves `nil` and drops the key from the surrounding map, mirroring the compile-time `maybe_put` semantic at `lib/juvet/template/compiler/encoder/helpers.ex:4`.
- Unblocks date/time pickers and text inputs with optional initial values (Slack rejects both `""` and `null` for these fields).

## What changed
- `lib/juvet/template.ex` (12 lines)
  - Single-EEx-expression binary branch: returns `nil` when the evaluated result is nil (boolean preservation from #abcf129 still intact; other types still stringify).
  - Map branch: walks via `Enum.reduce/3` and drops keys whose evaluated value is `nil` instead of putting them with `nil`.
- `test/juvet/template_test.exs` (+73 lines)
  - New `describe \"nil-valued attributes in single-EEx expressions\"` block with 6 tests:
    - Datepicker `initial_date: <%= maybe_date %>` &mdash; nil drops the key; real date keeps it.
    - Datepicker `focus_on_load: <%= maybe_focus %>` &mdash; nil drops the key; `true` is preserved.
    - Header `text: \"Hello <%= name %>\"` &mdash; multi-token EEx is **unchanged**; nil binding still renders as `\"Hello \"` (scope guard).

## Scope guard
- The behavior change is strictly limited to the `single_eex_expression?/1` true branch. Multi-token EEx (sentences with interpolation) routes through `EEx.eval_string` and retains its builtin nil-renders-as-empty behavior &mdash; covered by the third test case.
- Slack-required keys (`type`, `blocks`, etc.) are never `nil` at this layer because they're emitted via `Map.put/3`, not via runtime EEx &mdash; the nil-drop cannot accidentally remove a required field.

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] `mix test` passes &mdash; 672 tests, 0 failures, 2 skipped
- [x] Existing for-loop, code-block, partial, and template-helper tests untouched (366 template-pipeline tests green)

## Follow-ups
- **PR 2** (`feature/view-modal-envelope`): adds modal envelope fields (`title`, `submit`, `close`, `callback_id`, &hellip;) to `Slack.View.compile/1`. Depends on this PR for clean `nil` semantics on `private_metadata: <%= maybe_id %>` and friends.
- **PR 3** (`feature/cheex-if-block`): adds parser support for `<%= if &hellip; %>` / `<% else %>` / `<% end %>` and the corresponding `:if_block` AST node + runtime handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)