### PR TITLE
feat(template): support modal envelope fields in :slack.view

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -78,6 +78,50 @@ For Slack Block Kit, the compiled output looks like:
 }
 ```
 
+### Modal Views
+
+`:slack.view` with `type: :modal` supports the full Slack modal envelope. Every
+field except `type` and `blocks` is conditionally emitted &mdash; absent attributes
+do not appear in the output.
+
+```elixir
+# cheex source:
+#
+# :slack.view
+#   type: :modal
+#   callback_id: "submit_decision_modal"
+#   title: "New Decision"
+#   submit: "Save"
+#   close: "Cancel"
+#   private_metadata: "<%= decision_id %>"
+#   notify_on_close: true
+#   blocks:
+#     :slack.section{text: "Are you sure?"}
+
+%{
+  type: "modal",
+  callback_id: "submit_decision_modal",
+  title: %{type: "plain_text", text: "New Decision"},
+  submit: %{type: "plain_text", text: "Save"},
+  close: %{type: "plain_text", text: "Cancel"},
+  private_metadata: "abc-123",
+  notify_on_close: true,
+  blocks: [
+    %{type: "section", text: %{type: "mrkdwn", text: "Are you sure?"}}
+  ]
+}
+```
+
+Supported modal envelope fields: `callback_id`, `title`, `submit`, `close`,
+`private_metadata`, `clear_on_close`, `notify_on_close`, `external_id`,
+`submit_disabled`.
+
+`title:`, `submit:`, and `close:` accept either a plain string (autowrapped as
+a `plain_text` object) or a nested map of the form `%{text: "...", emoji: true}`.
+
+Juvet does not validate Slack's contract (e.g., `title.text` &le; 24 characters,
+`title` required for modals). Slack remains the authority for these rules.
+
 The template layer then either returns the map directly (`:map` format, the default)
 or encodes it to JSON (`:json` format) via `Encoder.encode!/1`.
 

--- a/lib/juvet/template/compiler/slack/view.ex
+++ b/lib/juvet/template/compiler/slack/view.ex
@@ -2,14 +2,31 @@ defmodule Juvet.Template.Compiler.Slack.View do
   @moduledoc false
 
   alias Juvet.Template.Compiler.Slack
+  alias Juvet.Template.Compiler.Slack.Objects.Text
 
   import Juvet.Template.Compiler.Encoder.Helpers, only: [maybe_put: 3]
 
   def compile(%{element: :view, attributes: attrs} = el) do
     %{type: to_string(attrs[:type])}
+    |> maybe_put(:callback_id, attrs[:callback_id])
+    |> maybe_put(:title, compile_text(attrs[:title]))
+    |> maybe_put(:submit, compile_text(attrs[:submit]))
+    |> maybe_put(:close, compile_text(attrs[:close]))
     |> maybe_put(:private_metadata, attrs[:private_metadata])
+    |> maybe_put(:clear_on_close, attrs[:clear_on_close])
+    |> maybe_put(:notify_on_close, attrs[:notify_on_close])
+    |> maybe_put(:external_id, attrs[:external_id])
+    |> maybe_put(:submit_disabled, attrs[:submit_disabled])
     |> Map.put(:blocks, compile_blocks(el))
   end
+
+  defp compile_text(nil), do: nil
+
+  defp compile_text(%{text: text} = attrs),
+    do: Text.compile(text, Map.put_new(attrs, :type, :plain_text))
+
+  defp compile_text(text) when is_binary(text),
+    do: Text.compile(text, %{type: :plain_text})
 
   defp compile_blocks(%{children: %{blocks: blocks}}) when is_list(blocks) do
     Enum.map(blocks, &Slack.compile_element/1)

--- a/test/juvet/template/compiler/slack/view_test.exs
+++ b/test/juvet/template/compiler/slack/view_test.exs
@@ -116,6 +116,284 @@ defmodule Juvet.Template.Compiler.Slack.ViewTest do
              }
     end
 
+    test "view with callback_id includes the callback_id field" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, callback_id: "submit_decision_modal"},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               callback_id: "submit_decision_modal",
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with title as a plain string wraps it in a plain_text object" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, title: "New Decision"},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               title: %{type: "plain_text", text: "New Decision"},
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with clear_on_close boolean includes the field" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, clear_on_close: true},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               clear_on_close: true,
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with title as a nested map honors text and emoji" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, title: %{text: "New Decision", emoji: true}},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               title: %{type: "plain_text", text: "New Decision", emoji: true},
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with submit as a string wraps it in a plain_text object" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, submit: "Save"},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               submit: %{type: "plain_text", text: "Save"},
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with close as a string wraps it in a plain_text object" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, close: "Cancel"},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               close: %{type: "plain_text", text: "Cancel"},
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with notify_on_close boolean includes the field" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, notify_on_close: true},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               notify_on_close: true,
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with external_id includes the field" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, external_id: "modal-42"},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               external_id: "modal-42",
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view with submit_disabled boolean includes the field" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, submit_disabled: true},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               submit_disabled: true,
+               blocks: [%{type: "divider"}]
+             }
+    end
+
+    test "view without modal envelope fields omits all of them" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      result = Slack.compile(ast)
+
+      refute Map.has_key?(result, :callback_id)
+      refute Map.has_key?(result, :title)
+      refute Map.has_key?(result, :submit)
+      refute Map.has_key?(result, :close)
+      refute Map.has_key?(result, :clear_on_close)
+      refute Map.has_key?(result, :notify_on_close)
+      refute Map.has_key?(result, :external_id)
+      refute Map.has_key?(result, :submit_disabled)
+    end
+
+    test "view with all modal envelope fields together" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{
+            type: :modal,
+            callback_id: "submit_decision_modal",
+            title: %{text: "New Decision", emoji: true},
+            submit: "Save",
+            close: "Cancel",
+            private_metadata: "decision-42",
+            clear_on_close: true,
+            notify_on_close: true,
+            external_id: "modal-42",
+            submit_disabled: false
+          },
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :section, attributes: %{text: "Are you sure?"}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               callback_id: "submit_decision_modal",
+               title: %{type: "plain_text", text: "New Decision", emoji: true},
+               submit: %{type: "plain_text", text: "Save"},
+               close: %{type: "plain_text", text: "Cancel"},
+               private_metadata: "decision-42",
+               clear_on_close: true,
+               notify_on_close: true,
+               external_id: "modal-42",
+               submit_disabled: false,
+               blocks: [
+                 %{type: "section", text: %{type: "mrkdwn", text: "Are you sure?"}}
+               ]
+             }
+    end
+
+    test "view with EEx interpolation in title text passes through at compile time" do
+      ast = [
+        %{
+          platform: :slack,
+          element: :view,
+          attributes: %{type: :modal, title: %{text: "<%= @subject %>", emoji: true}},
+          children: %{
+            blocks: [
+              %{platform: :slack, element: :divider, attributes: %{}}
+            ]
+          }
+        }
+      ]
+
+      assert Slack.compile(ast) == %{
+               type: "modal",
+               title: %{type: "plain_text", text: "<%= @subject %>", emoji: true},
+               blocks: [%{type: "divider"}]
+             }
+    end
+
     test "view with multiple block types inside blocks" do
       ast = [
         %{

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1724,4 +1724,63 @@ defmodule Juvet.TemplateTest do
       assert header.text.text == "Hello World"
     end
   end
+
+  describe "modal view envelope fields" do
+    defmodule ModalTemplates do
+      use Juvet.Template
+
+      template(:full_modal, """
+      :slack.view
+        type: :modal
+        callback_id: "submit_decision_modal"
+        title: "New Decision"
+        submit: "Save"
+        close: "Cancel"
+        private_metadata: "<%= decision_id %>"
+        notify_on_close: true
+        blocks:
+          :slack.section{text: "Are you sure?"}
+      """)
+
+      template(:modal_with_optional_external_id, """
+      :slack.view
+        type: :modal
+        title: "Pick a date"
+        external_id: <%= maybe_external %>
+        blocks:
+          :slack.divider
+      """)
+    end
+
+    test "full modal template compiles and evaluates with all envelope fields" do
+      result = ModalTemplates.full_modal(decision_id: "abc-123")
+
+      assert result == %{
+               type: "modal",
+               callback_id: "submit_decision_modal",
+               title: %{type: "plain_text", text: "New Decision"},
+               submit: %{type: "plain_text", text: "Save"},
+               close: %{type: "plain_text", text: "Cancel"},
+               private_metadata: "abc-123",
+               notify_on_close: true,
+               blocks: [
+                 %{type: "section", text: %{type: "mrkdwn", text: "Are you sure?"}}
+               ]
+             }
+    end
+
+    test "modal with nil-valued external_id drops the key at runtime" do
+      result = ModalTemplates.modal_with_optional_external_id(maybe_external: nil)
+
+      refute Map.has_key?(result, :external_id)
+      assert result.type == "modal"
+      assert result.title == %{type: "plain_text", text: "Pick a date"}
+    end
+
+    test "modal with a non-nil external_id includes the key" do
+      result = ModalTemplates.modal_with_optional_external_id(maybe_external: "modal-42")
+
+      assert result.external_id == "modal-42"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- **PR 2 of 3** in the cheex modal-support effort &mdash; builds on PR #118's clean `nil` semantics.
- Slack modal views require a richer top-level envelope than `home` views: `title` is mandatory, plus `callback_id`, `submit`/`close`, `clear_on_close`, `notify_on_close`, `external_id`, and `submit_disabled`. `View.compile/1` previously discarded all of them.
- Now every modal envelope field is emitted via `maybe_put`. Home views and existing tests are untouched.

## What changed
- `lib/juvet/template/compiler/slack/view.ex` (+17 lines)
  - 8 new `maybe_put` calls in the `View.compile/1` pipeline.
  - New private `compile_text/1` helper accepting either a plain string (autowrapped as `plain_text`) or a nested `%{text:, emoji:}` map &mdash; mirrors `Blocks.Input.compile_label/1` precedent.
- `test/juvet/template/compiler/slack/view_test.exs` (+278 lines)
  - 12 new unit tests &mdash; per-field presence/absence, `title:` string vs map shape, EEx interpolation passthrough, full combined envelope.
- `test/juvet/template_test.exs` (+59 lines)
  - 3 new end-to-end modal tests under `describe \"modal view envelope fields\"`, including a cross-PR regression test (`external_id: <%= maybe_external %>` with `nil` drops the key, demonstrating PR1 + PR2 work together).
- `docs/templates.md` (+44 lines)
  - New \"Modal Views\" subsection under Compiler Output Format with cheex source &rarr; compiled map example and the full list of supported envelope fields.

## API
```cheex
:slack.view
  type: :modal
  callback_id: \"submit_decision_modal\"
  title: \"New Decision\"          # or: title: %{text: \"New Decision\", emoji: true}
  submit: \"Save\"
  close: \"Cancel\"
  private_metadata: \"<%= decision_id %>\"
  notify_on_close: true
  blocks:
    :slack.section{text: \"Are you sure?\"}
```

## Scope guard
- Every new field is `maybe_put`, so absent attrs do not appear in the output.
- Juvet does not validate Slack's contract (e.g., `title.text` &le; 24 chars, `title` required for modals). Slack remains the authority &mdash; matches Juvet's existing posture for all other elements.
- Unknown view attributes are silently ignored (unchanged behavior).

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] `mix test` passes &mdash; 687 tests, 0 failures, 2 skipped
- [x] All 6 existing `view_test.exs` cases continue to pass without modification

## Follow-ups
- **PR 3** (`feature/cheex-if-block`): adds parser support for `<%= if &hellip; %>` / `<% else %>` / `<% end %>` and the corresponding `:if_block` AST node + runtime handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)