### PR TITLE
feat(template): support if/else expressions in cheex

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -62,6 +62,30 @@ Each element becomes a map:
 
 The `line` and `column` fields track where each element was defined in the original template source, enabling precise error messages during compilation.
 
+### Control-flow AST nodes
+
+EEx control-flow expressions produce dedicated AST nodes (no `:platform` or `:element` keys; identified by `:node_type`):
+
+```elixir
+# <%= for item <- items do %> ... <% end %>
+%{node_type: :for_loop, variable: "item", collection: "items", body: [...], line: 1, column: 1}
+
+# <%= if condition do %> ... <% else %> ... <% end %>
+%{
+  node_type: :if_block,
+  condition: "show",
+  then_body: [...],
+  else_body: [...] | nil,
+  line: 1,
+  column: 1
+}
+
+# <% code %>
+%{node_type: :code_block, code: "x = 1", line: 1, column: 1}
+```
+
+`if_block` accepts both `<% else %>` (standard EEx) and `<%= else %>` (Phoenix/LiveView style) tokens for the optional else branch. `elsif`, `unless`, `cond`, and `case` are intentionally not supported &mdash; use nested `if` blocks instead.
+
 ## Compiler Output Format
 
 The Compiler transforms the AST into atom-keyed maps for the target platform.

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -291,6 +291,15 @@ defmodule Juvet.Template do
         %{node_type: :for_loop} = node ->
           [%{node | body: resolve_partials(node.body, existing_asts, stack)}]
 
+        %{node_type: :if_block} = node ->
+          [
+            %{
+              node
+              | then_body: resolve_partials(node.then_body, existing_asts, stack),
+                else_body: resolve_partials_else_body(node.else_body, existing_asts, stack)
+            }
+          ]
+
         %{node_type: :code_block} = node ->
           [node]
 
@@ -302,6 +311,11 @@ defmodule Juvet.Template do
       end
     end)
   end
+
+  defp resolve_partials_else_body(nil, _existing_asts, _stack), do: nil
+
+  defp resolve_partials_else_body(list, existing_asts, stack) when is_list(list),
+    do: resolve_partials(list, existing_asts, stack)
 
   defp resolve_partials_in_children(children, existing_asts, stack) do
     Map.new(children, fn
@@ -497,6 +511,12 @@ defmodule Juvet.Template do
     end)
   end
 
+  def eval_map(%{__if__: true} = node, bindings) do
+    {result, _} = Code.eval_string(node.condition, bindings)
+    body = if result, do: node.then_body, else: node.else_body || []
+    flat_eval_body(body, bindings)
+  end
+
   def eval_map(data, bindings) when is_map(data) do
     Enum.reduce(data, %{}, fn {k, v}, acc ->
       case eval_map(v, bindings) do
@@ -507,9 +527,10 @@ defmodule Juvet.Template do
   end
 
   def eval_map(data, bindings) when is_list(data) do
-    if Enum.any?(data, &match?(%{__for__: true}, &1)) do
+    if Enum.any?(data, &flattening_marker?/1) do
       Enum.flat_map(data, fn
         %{__for__: true} = node -> eval_map(node, bindings)
+        %{__if__: true} = node -> eval_map(node, bindings)
         item -> [eval_map(item, bindings)]
       end)
     else
@@ -684,7 +705,8 @@ defmodule Juvet.Template do
 
   defp generate_json_function(name, compiled, helper_bindings) when is_map(compiled) do
     cond do
-      map_contains_for?(compiled) or map_contains_code_block?(compiled) ->
+      map_contains_for?(compiled) or map_contains_code_block?(compiled) or
+          map_contains_if?(compiled) ->
         bindings_var = Macro.var(:bindings, __MODULE__)
         body = compiled_to_quoted(compiled, bindings_var)
 
@@ -716,7 +738,8 @@ defmodule Juvet.Template do
 
   defp generate_map_function(name, compiled, helper_bindings) when is_map(compiled) do
     cond do
-      map_contains_for?(compiled) or map_contains_code_block?(compiled) ->
+      map_contains_for?(compiled) or map_contains_code_block?(compiled) or
+          map_contains_if?(compiled) ->
         bindings_var = Macro.var(:bindings, __MODULE__)
         body = compiled_to_quoted(compiled, bindings_var)
 
@@ -747,6 +770,36 @@ defmodule Juvet.Template do
   end
 
   # Transforms a compiled map/list structure into quoted Elixir AST.
+  # Handles __if__ markers by generating a real Elixir `if`/`else` expression
+  # whose condition is evaluated via `Code.eval_string` against the bindings,
+  # matching the trust model used for code blocks.
+  defp compiled_to_quoted(%{__if__: true} = node, bindings_var) do
+    condition = node.condition
+    then_body = node.then_body
+    else_body = node.else_body || []
+
+    then_quoted = if_body_quoted(then_body, bindings_var)
+    else_quoted = if_body_quoted(else_body, bindings_var)
+
+    quote do
+      {__if_result__, _} = Code.eval_string(unquote(condition), unquote(bindings_var))
+
+      if __if_result__ do
+        unquote(then_quoted)
+      else
+        unquote(else_quoted)
+      end
+    end
+  end
+
+  defp if_body_quoted(body, bindings_var) when is_list(body) do
+    escaped = Macro.escape(body)
+
+    quote do
+      Juvet.Template.flat_eval_body(unquote(escaped), unquote(bindings_var))
+    end
+  end
+
   # Handles __for__ markers by generating real `for` comprehensions.
   # When the for-loop body contains code blocks, uses binding threading.
   defp compiled_to_quoted(%{__for__: true} = node, bindings_var) do
@@ -795,6 +848,7 @@ defmodule Juvet.Template do
   defp compiled_to_quoted(list, bindings_var) when is_list(list) do
     has_code_blocks = Enum.any?(list, &match?(%{__code_block__: true}, &1))
     has_for_loops = Enum.any?(list, &match?(%{__for__: true}, &1))
+    has_if_blocks = Enum.any?(list, &match?(%{__if__: true}, &1))
 
     cond do
       has_code_blocks ->
@@ -811,10 +865,10 @@ defmodule Juvet.Template do
           elements
         end
 
-      has_for_loops ->
+      has_for_loops or has_if_blocks ->
         segments =
           list
-          |> Enum.chunk_by(&match?(%{__for__: true}, &1))
+          |> Enum.chunk_by(&flattening_marker?/1)
           |> Enum.flat_map(&chunk_to_quoted_segment(&1, bindings_var))
 
         quote do
@@ -871,8 +925,22 @@ defmodule Juvet.Template do
         end
       end)
 
-    case body_elements do
-      [single] ->
+    body_produces_lists = Enum.any?(body, &flattening_marker?/1)
+
+    cond do
+      body_produces_lists ->
+        quote do
+          Enum.flat_map(
+            Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)),
+            fn unquote(item_var) ->
+              Juvet.Template.flatten_results(unquote(body_elements))
+            end
+          )
+        end
+
+      match?([_], body_elements) ->
+        [single] = body_elements
+
         quote do
           for unquote(item_var) <-
                 Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)) do
@@ -880,12 +948,12 @@ defmodule Juvet.Template do
           end
         end
 
-      multiple ->
+      true ->
         quote do
           Enum.flat_map(
             Juvet.Template.resolve_binding(unquote(collection_path), unquote(bindings_var)),
             fn unquote(item_var) ->
-              Juvet.Template.flatten_results(unquote(multiple))
+              Juvet.Template.flatten_results(unquote(body_elements))
             end
           )
         end
@@ -1011,10 +1079,20 @@ defmodule Juvet.Template do
     end
   end
 
+  # Markers (for-loops, if-blocks) flatten into the surrounding list because they
+  # can produce 0 or N elements at runtime.
+  defp flattening_marker?(%{__for__: true}), do: true
+  defp flattening_marker?(%{__if__: true}), do: true
+  defp flattening_marker?(_), do: false
+
   # Converts a chunk of elements (from Enum.chunk_by) into Enum.concat segments.
-  # For-loop chunks become individual for comprehensions; static chunks become a literal list.
-  defp chunk_to_quoted_segment([%{__for__: true} | _] = chunk, bindings_var) do
-    Enum.map(chunk, &compiled_to_quoted(&1, bindings_var))
+  # Marker chunks become individual quoted expressions; static chunks become a literal list.
+  defp chunk_to_quoted_segment([first | _] = chunk, bindings_var) when is_map(first) do
+    if flattening_marker?(first) do
+      Enum.map(chunk, &compiled_to_quoted(&1, bindings_var))
+    else
+      [Enum.map(chunk, &compiled_to_quoted(&1, bindings_var))]
+    end
   end
 
   defp chunk_to_quoted_segment(static_elements, bindings_var) do
@@ -1095,6 +1173,12 @@ defmodule Juvet.Template do
     validate_platform!(node.body, expected)
   end
 
+  defp validate_platform_element!(%{node_type: :if_block} = node, expected) do
+    validate_platform!(node.then_body, expected)
+    if node.else_body, do: validate_platform!(node.else_body, expected)
+    :ok
+  end
+
   defp validate_platform_element!(%{node_type: :code_block}, _expected), do: :ok
 
   defp validate_platform_element!(%{platform: platform, line: line, column: col}, expected)
@@ -1152,4 +1236,15 @@ defmodule Juvet.Template do
     do: Enum.any?(list, &map_contains_for?/1)
 
   defp map_contains_for?(_), do: false
+
+  # Checks if a compiled structure contains any __if__ markers.
+  defp map_contains_if?(%{__if__: true}), do: true
+
+  defp map_contains_if?(map) when is_map(map),
+    do: Enum.any?(map, fn {_k, v} -> map_contains_if?(v) end)
+
+  defp map_contains_if?(list) when is_list(list),
+    do: Enum.any?(list, &map_contains_if?/1)
+
+  defp map_contains_if?(_), do: false
 end

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -705,8 +705,7 @@ defmodule Juvet.Template do
 
   defp generate_json_function(name, compiled, helper_bindings) when is_map(compiled) do
     cond do
-      map_contains_for?(compiled) or map_contains_code_block?(compiled) or
-          map_contains_if?(compiled) ->
+      map_contains_dynamic_marker?(compiled) ->
         bindings_var = Macro.var(:bindings, __MODULE__)
         body = compiled_to_quoted(compiled, bindings_var)
 
@@ -738,8 +737,7 @@ defmodule Juvet.Template do
 
   defp generate_map_function(name, compiled, helper_bindings) when is_map(compiled) do
     cond do
-      map_contains_for?(compiled) or map_contains_code_block?(compiled) or
-          map_contains_if?(compiled) ->
+      map_contains_dynamic_marker?(compiled) ->
         bindings_var = Macro.var(:bindings, __MODULE__)
         body = compiled_to_quoted(compiled, bindings_var)
 
@@ -1247,4 +1245,11 @@ defmodule Juvet.Template do
     do: Enum.any?(list, &map_contains_if?/1)
 
   defp map_contains_if?(_), do: false
+
+  # Any dynamic marker (__for__, __code_block__, __if__) means the structure
+  # cannot be statically encoded and must route through compiled_to_quoted/2.
+  defp map_contains_dynamic_marker?(compiled) do
+    map_contains_for?(compiled) or map_contains_code_block?(compiled) or
+      map_contains_if?(compiled)
+  end
 end

--- a/lib/juvet/template/compiler/slack.ex
+++ b/lib/juvet/template/compiler/slack.ex
@@ -79,6 +79,15 @@ defmodule Juvet.Template.Compiler.Slack do
     }
   end
 
+  def compile_element(%{node_type: :if_block} = node) do
+    %{
+      __if__: true,
+      condition: node.condition,
+      then_body: Enum.map(node.then_body, &compile_element/1),
+      else_body: compile_else_body(node.else_body)
+    }
+  end
+
   def compile_element(%{element: :actions} = el), do: Actions.compile(el)
   def compile_element(%{element: :button} = el), do: Button.compile(el)
   def compile_element(%{element: :checkboxes} = el), do: Checkboxes.compile(el)
@@ -136,4 +145,7 @@ defmodule Juvet.Template.Compiler.Slack do
   def compile_element(%{element: element}) do
     raise ArgumentError, "Unknown Slack element: #{inspect(element)}"
   end
+
+  defp compile_else_body(nil), do: nil
+  defp compile_else_body(list) when is_list(list), do: Enum.map(list, &compile_element/1)
 end

--- a/lib/juvet/template/parser.ex
+++ b/lib/juvet/template/parser.ex
@@ -43,28 +43,19 @@ defmodule Juvet.Template.Parser do
   defp do_parse([{:dedent, _, _} | rest], acc, platform), do: do_parse(rest, acc, platform)
   defp do_parse([{:newline, _, _} | rest], acc, platform), do: do_parse(rest, acc, platform)
 
-  # EEx expression at top level - detect for-loop or skip
+  # EEx expression at top level - detect for-loop, if-block, or raise
   defp do_parse([{:eex_expr, expr, pos} | rest], acc, platform) do
-    case parse_for_expression(expr) do
-      {:ok, variable, collection} ->
+    case classify_eex_expression(expr) do
+      {:for, variable, collection} ->
         {body, rest} = parse_for_body(rest, [], platform)
+        do_parse(rest, [for_loop_node(variable, collection, body, pos) | acc], platform)
 
-        for_node = %{
-          node_type: :for_loop,
-          variable: variable,
-          collection: collection,
-          body: body,
-          line: elem(pos, 0),
-          column: elem(pos, 1)
-        }
+      {:if, condition} ->
+        {then_body, else_body, rest} = parse_if_body(rest, [], platform)
+        do_parse(rest, [if_block_node(condition, then_body, else_body, pos) | acc], platform)
 
-        do_parse(rest, [for_node | acc], platform)
-
-      :error ->
-        raise ParserError,
-          message: "Unsupported EEx expression '#{expr}', only for loops are supported",
-          line: elem(pos, 0),
-          column: elem(pos, 1)
+      :unknown ->
+        raise_unsupported_eex(expr, pos)
     end
   end
 
@@ -279,6 +270,7 @@ defmodule Juvet.Template.Parser do
   # so they must stay wrapped in a list.
   defp child_value([%{node_type: :for_loop}] = list), do: list
   defp child_value([%{node_type: :code_block}] = list), do: list
+  defp child_value([%{node_type: :if_block}] = list), do: list
   defp child_value([single]), do: single
   defp child_value(multiple), do: multiple
 
@@ -300,28 +292,24 @@ defmodule Juvet.Template.Parser do
     nested_elements(rest, [el | acc], platform)
   end
 
-  # EEx expression inside nested elements - detect for-loop
+  # EEx expression inside nested elements - detect for-loop or if-block
   defp nested_elements([{:eex_expr, expr, pos} | rest], acc, platform) do
-    case parse_for_expression(expr) do
-      {:ok, variable, collection} ->
+    case classify_eex_expression(expr) do
+      {:for, variable, collection} ->
         {body, rest} = parse_for_body(rest, [], platform)
+        nested_elements(rest, [for_loop_node(variable, collection, body, pos) | acc], platform)
 
-        for_node = %{
-          node_type: :for_loop,
-          variable: variable,
-          collection: collection,
-          body: body,
-          line: elem(pos, 0),
-          column: elem(pos, 1)
-        }
+      {:if, condition} ->
+        {then_body, else_body, rest} = parse_if_body(rest, [], platform)
 
-        nested_elements(rest, [for_node | acc], platform)
+        nested_elements(
+          rest,
+          [if_block_node(condition, then_body, else_body, pos) | acc],
+          platform
+        )
 
-      :error ->
-        raise ParserError,
-          message: "Unsupported EEx expression '#{expr}', only for loops are supported",
-          line: elem(pos, 0),
-          column: elem(pos, 1)
+      :unknown ->
+        raise_unsupported_eex(expr, pos)
     end
   end
 
@@ -417,14 +405,54 @@ defmodule Juvet.Template.Parser do
     end
   end
 
-  # Parses a for-loop expression like "for item <- items do",
-  # "for item <- parent.items do", or "for item <- helper.(items) do"
-  # Returns {:ok, variable, collection_expression} or :error
-  defp parse_for_expression(expr) do
-    case Regex.run(~r/\Afor\s+(\w+)\s*<-\s*(.+)\s+do\z/, expr) do
-      [_, variable, collection] -> {:ok, variable, String.trim(collection)}
-      _ -> :error
+  # Classifies an EEx expression into a dispatch tag. Designed so future
+  # additions (e.g. variable spread) slot in as new arms without disturbing
+  # existing call sites; the :unknown arm preserves back-compat raising.
+  defp classify_eex_expression(expr) do
+    cond do
+      match = Regex.run(~r/\Afor\s+(\w+)\s*<-\s*(.+)\s+do\z/, expr) ->
+        [_, variable, collection] = match
+        {:for, variable, String.trim(collection)}
+
+      match = Regex.run(~r/\Aif\s+(.+)\s+do\z/, expr) ->
+        [_, condition] = match
+        {:if, String.trim(condition)}
+
+      String.trim(expr) == "else" ->
+        :else
+
+      true ->
+        :unknown
     end
+  end
+
+  defp for_loop_node(variable, collection, body, {line, col}) do
+    %{
+      node_type: :for_loop,
+      variable: variable,
+      collection: collection,
+      body: body,
+      line: line,
+      column: col
+    }
+  end
+
+  defp if_block_node(condition, then_body, else_body, {line, col}) do
+    %{
+      node_type: :if_block,
+      condition: condition,
+      then_body: then_body,
+      else_body: else_body,
+      line: line,
+      column: col
+    }
+  end
+
+  defp raise_unsupported_eex(expr, {line, col}) do
+    raise ParserError,
+      message: "Unsupported EEx expression '#{expr}', only for loops are supported",
+      line: line,
+      column: col
   end
 
   # Collects elements inside a for-loop body until {:eex_code, "end", _}.
@@ -471,26 +499,22 @@ defmodule Juvet.Template.Parser do
   end
 
   defp parse_for_body([{:eex_expr, expr, pos} | rest], acc, platform) do
-    case parse_for_expression(expr) do
-      {:ok, variable, collection} ->
+    case classify_eex_expression(expr) do
+      {:for, variable, collection} ->
         {body, rest} = parse_for_body(rest, [], platform)
+        parse_for_body(rest, [for_loop_node(variable, collection, body, pos) | acc], platform)
 
-        for_node = %{
-          node_type: :for_loop,
-          variable: variable,
-          collection: collection,
-          body: body,
-          line: elem(pos, 0),
-          column: elem(pos, 1)
-        }
+      {:if, condition} ->
+        {then_body, else_body, rest} = parse_if_body(rest, [], platform)
 
-        parse_for_body(rest, [for_node | acc], platform)
+        parse_for_body(
+          rest,
+          [if_block_node(condition, then_body, else_body, pos) | acc],
+          platform
+        )
 
-      :error ->
-        raise ParserError,
-          message: "Unsupported EEx expression '#{expr}', only for loops are supported",
-          line: elem(pos, 0),
-          column: elem(pos, 1)
+      :unknown ->
+        raise_unsupported_eex(expr, pos)
     end
   end
 
@@ -511,5 +535,176 @@ defmodule Juvet.Template.Parser do
       message: "Unexpected end of template, expected <% end %> to close for loop",
       line: nil,
       column: nil
+  end
+
+  # Collects elements inside an if-block body until <% else %> or <% end %>.
+  # Returns {then_body, else_body | nil, remaining_tokens}.
+  defp parse_if_body([{:eex_code, "end", _} | rest], acc, _platform) do
+    {Enum.reverse(acc), nil, rest}
+  end
+
+  defp parse_if_body([{:eex_code, "else", _} | rest], acc, platform) do
+    {else_body, rest} = parse_else_body(rest, [], platform)
+    {Enum.reverse(acc), else_body, rest}
+  end
+
+  defp parse_if_body([{:eex_expr, "else", _} | rest], acc, platform) do
+    {else_body, rest} = parse_else_body(rest, [], platform)
+    {Enum.reverse(acc), else_body, rest}
+  end
+
+  defp parse_if_body([], _acc, _platform) do
+    raise ParserError,
+      message: "Unexpected end of template, expected <% end %> to close if block",
+      line: nil,
+      column: nil
+  end
+
+  defp parse_if_body([{:eof, _, _}], _acc, _platform) do
+    raise ParserError,
+      message: "Unexpected end of template, expected <% end %> to close if block",
+      line: nil,
+      column: nil
+  end
+
+  defp parse_if_body([{:newline, _, _} | rest], acc, platform),
+    do: parse_if_body(rest, acc, platform)
+
+  defp parse_if_body([{:whitespace, _, _} | rest], acc, platform),
+    do: parse_if_body(rest, acc, platform)
+
+  defp parse_if_body([{:indent, _, _} | rest], acc, platform),
+    do: parse_if_body(rest, acc, platform)
+
+  defp parse_if_body([{:dedent, _, _} | rest], acc, platform),
+    do: parse_if_body(rest, acc, platform)
+
+  defp parse_if_body([{:colon, _, _} | _] = tokens, acc, platform) do
+    {el, rest} = element(tokens)
+    parse_if_body(rest, [el | acc], platform)
+  end
+
+  defp parse_if_body([{:dot, _, _} | _] = tokens, acc, platform) when platform != nil do
+    {el, rest} = element(tokens, platform)
+    parse_if_body(rest, [el | acc], platform)
+  end
+
+  defp parse_if_body([{:dot, _, {line, col}} | _], _acc, _platform) do
+    raise ParserError,
+      message:
+        "Element with '.' shorthand must be inside a parent element that specifies a platform",
+      line: line,
+      column: col
+  end
+
+  defp parse_if_body([{:eex_expr, expr, pos} | rest], acc, platform) do
+    case classify_eex_expression(expr) do
+      {:for, variable, collection} ->
+        {body, rest} = parse_for_body(rest, [], platform)
+        parse_if_body(rest, [for_loop_node(variable, collection, body, pos) | acc], platform)
+
+      {:if, condition} ->
+        {then_body, else_body, rest} = parse_if_body(rest, [], platform)
+
+        parse_if_body(
+          rest,
+          [if_block_node(condition, then_body, else_body, pos) | acc],
+          platform
+        )
+
+      :unknown ->
+        raise_unsupported_eex(expr, pos)
+    end
+  end
+
+  defp parse_if_body([{:eex_code, code, pos} | rest], acc, platform) do
+    code_block = %{
+      node_type: :code_block,
+      code: String.trim(code),
+      line: elem(pos, 0),
+      column: elem(pos, 1)
+    }
+
+    parse_if_body(rest, [code_block | acc], platform)
+  end
+
+  # Collects elements inside an if-block else_body until <% end %>.
+  defp parse_else_body([{:eex_code, "end", _} | rest], acc, _platform) do
+    {Enum.reverse(acc), rest}
+  end
+
+  defp parse_else_body([], _acc, _platform) do
+    raise ParserError,
+      message: "Unexpected end of template, expected <% end %> to close if/else block",
+      line: nil,
+      column: nil
+  end
+
+  defp parse_else_body([{:eof, _, _}], _acc, _platform) do
+    raise ParserError,
+      message: "Unexpected end of template, expected <% end %> to close if/else block",
+      line: nil,
+      column: nil
+  end
+
+  defp parse_else_body([{:newline, _, _} | rest], acc, platform),
+    do: parse_else_body(rest, acc, platform)
+
+  defp parse_else_body([{:whitespace, _, _} | rest], acc, platform),
+    do: parse_else_body(rest, acc, platform)
+
+  defp parse_else_body([{:indent, _, _} | rest], acc, platform),
+    do: parse_else_body(rest, acc, platform)
+
+  defp parse_else_body([{:dedent, _, _} | rest], acc, platform),
+    do: parse_else_body(rest, acc, platform)
+
+  defp parse_else_body([{:colon, _, _} | _] = tokens, acc, platform) do
+    {el, rest} = element(tokens)
+    parse_else_body(rest, [el | acc], platform)
+  end
+
+  defp parse_else_body([{:dot, _, _} | _] = tokens, acc, platform) when platform != nil do
+    {el, rest} = element(tokens, platform)
+    parse_else_body(rest, [el | acc], platform)
+  end
+
+  defp parse_else_body([{:dot, _, {line, col}} | _], _acc, _platform) do
+    raise ParserError,
+      message:
+        "Element with '.' shorthand must be inside a parent element that specifies a platform",
+      line: line,
+      column: col
+  end
+
+  defp parse_else_body([{:eex_expr, expr, pos} | rest], acc, platform) do
+    case classify_eex_expression(expr) do
+      {:for, variable, collection} ->
+        {body, rest} = parse_for_body(rest, [], platform)
+        parse_else_body(rest, [for_loop_node(variable, collection, body, pos) | acc], platform)
+
+      {:if, condition} ->
+        {then_body, else_body, rest} = parse_if_body(rest, [], platform)
+
+        parse_else_body(
+          rest,
+          [if_block_node(condition, then_body, else_body, pos) | acc],
+          platform
+        )
+
+      :unknown ->
+        raise_unsupported_eex(expr, pos)
+    end
+  end
+
+  defp parse_else_body([{:eex_code, code, pos} | rest], acc, platform) do
+    code_block = %{
+      node_type: :code_block,
+      code: String.trim(code),
+      line: elem(pos, 0),
+      column: elem(pos, 1)
+    }
+
+    parse_else_body(rest, [code_block | acc], platform)
   end
 end

--- a/test/juvet/template/compiler/slack_test.exs
+++ b/test/juvet/template/compiler/slack_test.exs
@@ -5228,4 +5228,54 @@ defmodule Juvet.Template.Compiler.SlackTest do
              ] = result.blocks
     end
   end
+
+  describe "compile_element/1 with if_block" do
+    test "if_block AST node compiles to __if__ marker with recursively compiled bodies" do
+      node = %{
+        node_type: :if_block,
+        condition: "@show",
+        then_body: [
+          %{platform: :slack, element: :section, attributes: %{text: "Yes"}}
+        ],
+        else_body: [
+          %{platform: :slack, element: :divider, attributes: %{}}
+        ],
+        line: 1,
+        column: 1
+      }
+
+      result = Slack.compile_element(node)
+
+      assert result == %{
+               __if__: true,
+               condition: "@show",
+               then_body: [
+                 %{type: "section", text: %{type: "mrkdwn", text: "Yes"}}
+               ],
+               else_body: [%{type: "divider"}]
+             }
+    end
+
+    test "if_block with nil else_body preserves nil in marker" do
+      node = %{
+        node_type: :if_block,
+        condition: "@show",
+        then_body: [
+          %{platform: :slack, element: :divider, attributes: %{}}
+        ],
+        else_body: nil,
+        line: 1,
+        column: 1
+      }
+
+      result = Slack.compile_element(node)
+
+      assert result == %{
+               __if__: true,
+               condition: "@show",
+               then_body: [%{type: "divider"}],
+               else_body: nil
+             }
+    end
+  end
 end

--- a/test/juvet/template/parser_test.exs
+++ b/test/juvet/template/parser_test.exs
@@ -26,6 +26,16 @@ defmodule Juvet.Template.ParserTest do
     |> Map.update!(:body, &strip_positions/1)
   end
 
+  defp strip_positions(%{node_type: :if_block} = node) do
+    node
+    |> Map.drop([:line, :column])
+    |> Map.update!(:then_body, &strip_positions/1)
+    |> Map.update!(:else_body, fn
+      nil -> nil
+      list when is_list(list) -> strip_positions(list)
+    end)
+  end
+
   defp strip_positions(%{node_type: :code_block} = node) do
     Map.drop(node, [:line, :column])
   end
@@ -669,6 +679,112 @@ defmodule Juvet.Template.ParserTest do
       assert node.column == 1
       assert node.node_type == :code_block
       assert node.code == "x = 1"
+    end
+  end
+
+  describe "parse/1 - Phase 12: If-block support" do
+    test "simple if-block without else produces if_block AST with nil else_body" do
+      template = "<%= if @show do %>\n:slack.section{text: \"Visible\"}\n<% end %>"
+
+      assert parse(template) == [
+               %{
+                 node_type: :if_block,
+                 condition: "@show",
+                 then_body: [
+                   %{
+                     platform: :slack,
+                     element: :section,
+                     attributes: %{text: "Visible"}
+                   }
+                 ],
+                 else_body: nil
+               }
+             ]
+    end
+
+    test "if-block with else splits then_body and else_body" do
+      template =
+        "<%= if @show do %>\n:slack.section{text: \"Yes\"}\n<% else %>\n:slack.section{text: \"No\"}\n<% end %>"
+
+      assert parse(template) == [
+               %{
+                 node_type: :if_block,
+                 condition: "@show",
+                 then_body: [
+                   %{
+                     platform: :slack,
+                     element: :section,
+                     attributes: %{text: "Yes"}
+                   }
+                 ],
+                 else_body: [
+                   %{
+                     platform: :slack,
+                     element: :section,
+                     attributes: %{text: "No"}
+                   }
+                 ]
+               }
+             ]
+    end
+
+    test "if-block accepts both <% else %> and <%= else %> forms" do
+      template_strict =
+        "<%= if @show do %>\n:slack.divider\n<% else %>\n:slack.section{text: \"No\"}\n<% end %>"
+
+      template_eq =
+        "<%= if @show do %>\n:slack.divider\n<%= else %>\n:slack.section{text: \"No\"}\n<% end %>"
+
+      assert parse(template_strict) == parse(template_eq)
+    end
+
+    test "if-block inside element children uses platform inheritance" do
+      template =
+        ":slack.view\n  type: :modal\n  blocks:\n    <%= if @show do %>\n    .section{text: \"Hi\"}\n    <% end %>"
+
+      [view] = parse(template)
+      blocks = view.children.blocks
+
+      assert [if_node] = blocks
+      assert if_node.node_type == :if_block
+      assert if_node.condition == "@show"
+      assert length(if_node.then_body) == 1
+      assert hd(if_node.then_body).element == :section
+      assert hd(if_node.then_body).platform == :slack
+      assert if_node.else_body == nil
+    end
+
+    test "if-block nested inside for-loop body" do
+      template =
+        "<%= for item <- items do %>\n<%= if item.show do %>\n:slack.section{text: \"<%= item.text %>\"}\n<% end %>\n<% end %>"
+
+      [for_node] = parse(template)
+      assert for_node.node_type == :for_loop
+      assert length(for_node.body) == 1
+
+      [if_node] = for_node.body
+      assert if_node.node_type == :if_block
+      assert if_node.condition == "item.show"
+      assert length(if_node.then_body) == 1
+      assert hd(if_node.then_body).element == :section
+    end
+
+    test "unsupported EEx expressions like unless still raise ParserError" do
+      template = "<%= unless @hidden do %>\n:slack.divider\n<% end %>"
+
+      assert_raise Juvet.Template.Parser.Error,
+                   ~r/Unsupported EEx expression/,
+                   fn -> parse(template) end
+    end
+
+    test "if-block includes line and column" do
+      template = "<%= if @x do %>\n:slack.divider\n<% end %>"
+
+      [node] = parse_with_positions(template)
+
+      assert node.node_type == :if_block
+      assert node.line == 1
+      assert node.column == 1
     end
   end
 

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1783,4 +1783,86 @@ defmodule Juvet.TemplateTest do
       assert result.external_id == "modal-42"
     end
   end
+
+  describe "if/else expressions in cheex" do
+    defmodule IfBlockTemplates do
+      use Juvet.Template
+
+      template(:simple_if, """
+      :slack.view
+        type: :modal
+        blocks:
+          <%= if show do %>
+            .section{text: "Visible"}
+          <% end %>
+      """)
+
+      template(:if_else, """
+      :slack.view
+        type: :modal
+        blocks:
+          <%= if show do %>
+            .section{text: "Yes"}
+          <% else %>
+            .section{text: "No"}
+          <% end %>
+      """)
+
+      template(:if_inside_for, """
+      :slack.view
+        type: :modal
+        blocks:
+          <%= for item <- items do %>
+            <%= if item.show do %>
+              .section{text: "<%= item.label %>"}
+            <% end %>
+          <% end %>
+      """)
+    end
+
+    test "if-block with truthy condition renders then_body" do
+      result = IfBlockTemplates.simple_if(show: true)
+
+      assert result.blocks == [
+               %{type: "section", text: %{type: "mrkdwn", text: "Visible"}}
+             ]
+    end
+
+    test "if-block with falsy condition renders nothing when else_body is absent" do
+      result = IfBlockTemplates.simple_if(show: false)
+
+      assert result.blocks == []
+    end
+
+    test "if-else with truthy condition renders then_body" do
+      result = IfBlockTemplates.if_else(show: true)
+
+      assert result.blocks == [
+               %{type: "section", text: %{type: "mrkdwn", text: "Yes"}}
+             ]
+    end
+
+    test "if-else with falsy condition renders else_body" do
+      result = IfBlockTemplates.if_else(show: false)
+
+      assert result.blocks == [
+               %{type: "section", text: %{type: "mrkdwn", text: "No"}}
+             ]
+    end
+
+    test "if-block nested inside for-loop filters iterations" do
+      items = [
+        %{show: true, label: "first"},
+        %{show: false, label: "skipped"},
+        %{show: true, label: "third"}
+      ]
+
+      result = IfBlockTemplates.if_inside_for(items: items)
+
+      assert result.blocks == [
+               %{type: "section", text: %{type: "mrkdwn", text: "first"}},
+               %{type: "section", text: %{type: "mrkdwn", text: "third"}}
+             ]
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- **PR 3 of 3** in the cheex modal-support effort &mdash; completes end-to-end modal authoring with conditional sections.
- Modal authoring routinely needs conditional rendering ("show submit only on confirmation step"; "swap which block renders based on a flag"). The parser previously raised `"only for loops are supported"` for any EEx expression other than `for ... do`.
- Add full `<%= if condition do %> ... <% else %> ... <% end %>` support across parser, compiler, and runtime &mdash; mirrors the established `:for_loop` blueprint.

## What changed
- **Parser** (`lib/juvet/template/parser.ex`)
  - New `classify_eex_expression/1` dispatcher returns `{:for, var, coll} | {:if, condition} | :else | :unknown`.
  - Three "raise unless `for`" call sites (top-level, nested elements, for-body) replaced with dispatcher; the `:unknown` arm preserves the existing `ParserError` so `unless` / `cond` / `case` still raise.
  - New `parse_if_body/3` + `parse_else_body/3` collect then/else children, mirroring `parse_for_body/3`.
  - Emits `%{node_type: :if_block, condition, then_body, else_body, line, column}` AST nodes.
  - Both `<% else %>` (standard EEx) and `<%= else %>` (Phoenix/LiveView style) accepted.
  - Dispatcher is intentionally structured so adding a future `:variable` arm (variable-spread) is a one-line change.
- **Compiler** (`lib/juvet/template/compiler/slack.ex`)
  - New `compile_element/1` clause emits `%{__if__: true, condition, then_body, else_body}` marker map with recursively compiled bodies.
- **Runtime** (`lib/juvet/template.ex`)
  - `map_contains_if?/1` detector routes if-block templates through the quoted-AST path.
  - `compiled_to_quoted/2` for `__if__` emits a real Elixir `if`/`else` expression closing over `bindings_var`. Condition evaluated via `Code.eval_string` &mdash; same trust model as code blocks (PR #111).
  - `eval_map/2` interpreted clause for `__if__` handles the runtime path used when an if-block sits inside a for-loop body.
  - List branch of `eval_map` and `compiled_to_quoted` extended to flatten `__if__` results alongside `__for__`.
  - `for_quoted_without_code_blocks` extended to use `Enum.flat_map` when the for-body contains flattening markers (avoids list-of-lists from single-body if-inside-for).
  - `resolve_partials` and `validate_platform!` get passthrough clauses for `:if_block` AST nodes.
- **Tests**: +7 parser tests (Phase 12), +2 compiler tests, +5 end-to-end template tests covering truthy/falsy, if/else, and if-inside-for.
- **Docs**: `docs/templates.md` "Control-flow AST nodes" subsection documents `:if_block` alongside `:for_loop` and `:code_block`.

## Scope guard
- `elsif` / `unless` / `cond` / `case` intentionally not supported &mdash; nest \`if\` blocks instead. Dispatcher leaves an `:unknown` arm so any other expression raises the existing error.
- Variable-spread (`<%= my_var %>` at element position) is explicitly out of scope; the dispatcher's structure makes adding it a one-arm change in a future PR.
- Existing for-loop tests are unaffected &mdash; the dispatcher returns the same `{:for, var, coll}` tuple they always relied on.

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes (no `Refactor.Nesting` / `CyclomaticComplexity` issues introduced)
- [x] `mix test` passes &mdash; 701 tests, 0 failures, 2 skipped
- [x] All 61 existing parser tests pass without modification

## Closes
Completes the cheex modal-support effort begun in PR #118 (nil-drop in eval_map) and PR #119 (modal envelope fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)