### PR TITLE
refactor(template): group compiled_to_quoted/2 clauses together

### DIFF
--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -790,14 +790,6 @@ defmodule Juvet.Template do
     end
   end
 
-  defp if_body_quoted(body, bindings_var) when is_list(body) do
-    escaped = Macro.escape(body)
-
-    quote do
-      Juvet.Template.flat_eval_body(unquote(escaped), unquote(bindings_var))
-    end
-  end
-
   # Handles __for__ markers by generating real `for` comprehensions.
   # When the for-loop body contains code blocks, uses binding threading.
   defp compiled_to_quoted(%{__for__: true} = node, bindings_var) do
@@ -889,6 +881,16 @@ defmodule Juvet.Template do
   end
 
   defp compiled_to_quoted(value, _bindings_var), do: Macro.escape(value)
+
+  # Builds a quoted expression that evaluates an if-block body (then or else)
+  # against the bindings at runtime.
+  defp if_body_quoted(body, bindings_var) when is_list(body) do
+    escaped = Macro.escape(body)
+
+    quote do
+      Juvet.Template.flat_eval_body(unquote(escaped), unquote(bindings_var))
+    end
+  end
 
   # For-loop quoted AST when body contains code blocks - uses binding threading.
   defp for_quoted_with_code_blocks(body, variable, collection_path, item_var, bindings_var) do


### PR DESCRIPTION
## Summary
Move the private `if_body_quoted/2` helper out from between the `__if__` and `__for__` clauses of `compiled_to_quoted/2` so all seven clauses are consecutive.

## Why
- Elixir 1.14.1 (juvet's CI version) only emits the "clauses with the same name and arity should be grouped together" warning for `def`, not `defp`. So this slipped through PR #120's CI even though I caught and fixed the same issue for `def compile_element/1` and `def eval_map/2` in that PR.
- Newer Elixir versions (1.16+) extended the check to `defp` clauses too. Surfaced via a downstream agent compiling against juvet on a newer toolchain.
- Pure style; addresses the warning when juvet is consumed by projects on newer Elixir.

## What changed
- `lib/juvet/template.ex` &mdash; `defp if_body_quoted/2` moved from between the `__if__` and `__for__` clauses (was at line 793) to after the catch-all `defp compiled_to_quoted(value, _)` clause (now at line 887). All 7 `compiled_to_quoted/2` clauses are now consecutive: 774, 795, 808, 829, 838, 873, 883.

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix compile --force --warnings-as-errors` passes (no new warnings)
- [x] `mix credo --strict` passes
- [x] `mix test` passes &mdash; 701 tests, 0 failures, 2 skipped
- [x] No behavior change &mdash; pure code-motion refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)