### PR TITLE
fix(test): clean up ViewStateRegistry after ViewStateTest module

### DIFF
--- a/test/juvet/view_state_test.exs
+++ b/test/juvet/view_state_test.exs
@@ -4,7 +4,13 @@ defmodule Juvet.ViewStateTest do
   alias Juvet.{ViewState, ViewStateRegistry}
 
   setup_all do
-    ViewStateRegistry.start_link()
+    unless Process.whereis(ViewStateRegistry.name()) do
+      {:ok, _} = ViewStateRegistry.start_link()
+    end
+
+    on_exit(fn ->
+      if Process.whereis(ViewStateRegistry.name()), do: ViewStateRegistry.stop()
+    end)
 
     :ok
   end


### PR DESCRIPTION
## Summary
`Juvet.ViewStateTest.setup_all` starts `ViewStateRegistry` via `start_link()` (unsupervised), leaving the named process `:view_state_registry` alive after the test module exits. Subsequent test modules that bring up `BotFactory` &rarr; `ViewStateManager` &rarr; `ViewStateRegistry` under `start_supervised!` fail with `(EXIT) already started: <pid>`.

On Elixir 1.14 / OTP 25 the random test ordering happened to mask this in the current CI &mdash; on Elixir 1.19 / OTP 28 (or any order where `ViewStateTest` runs before `Juvet.Bot.BotTest`) it deterministically fails 7 BotTests.

## Reproduction
```sh
# 1.19/OTP 28 with seed 0:
mix test test/juvet/view_state_test.exs test/juvet/bot_test.exs --seed 0
# 16 tests, 7 failures (all `(EXIT) shutdown: failed to start child: Juvet.ViewStateRegistry / already started`)
```

## What changed
`test/juvet/view_state_test.exs` &mdash; `setup_all` now:
1. Guards the `start_link` so it doesn't double-start if the registry is already running.
2. Registers an `on_exit` that calls `ViewStateRegistry.stop()` when the test module finishes, releasing the named process before the next module runs.

Mirrors the existing defensive "check whereis, then stop" pattern in `test/juvet/view_state_registry_test.exs:9`.

## Test plan
- [x] `mix test test/juvet/view_state_test.exs test/juvet/bot_test.exs --seed 0` &mdash; was 7 failures, now 0
- [x] **1.14.1 / OTP 25** full suite: 701 tests, 0 failures, 2 skipped (baseline preserved)
- [x] **1.19.5 / OTP 28.3** full suite: 701 tests, 0 failures, 2 skipped (was 7 failures)
- [x] `mix credo --strict` clean on both versions
- [x] `mix format --check-formatted` clean

## Follow-up
After this merges, a **PR C** will add Elixir 1.19 to the CI matrix in `.github/workflows/ci.yml` (the original goal &mdash; PR A bumped dependencies and addressed lint warnings, this PR fixes the test correctness gap, PR C enables the matrix). All blockers for adding the second matrix slot are now cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)