### PR TITLE
chore(ci): add Elixir 1.19.5 / OTP 28 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.14.1]
-        otp: [25.0.4]
+        include:
+          - elixir: '1.14.1'
+            otp: '25.0.4'
+          - elixir: '1.19.5'
+            otp: '28.0.0'
 
     steps:
     - name: Setup Elixir


### PR DESCRIPTION
## Summary
Adds a second matrix entry so CI runs on both the current floor (Elixir 1.14.1 / OTP 25.0.4) and the latest stable Elixir (1.19.5 / OTP 28.0.0) in parallel.

## Why
- Closes the gap surfaced by the cheex if-block PR (#120 review &rarr; #122 follow-up): newer-Elixir-only warnings (the `defp` clause-grouping check introduced in 1.16+) silently slipped through single-version 1.14 CI and surfaced for downstream consumers compiling against juvet on newer Elixir.
- Matches the empirical pattern across Req, Phoenix, Ecto, and Plug &mdash; a slim hand-curated matrix (not a cross-product), with `--warnings-as-errors` running on both slots.
- See `project_elixir_version_strategy` research notes for the full analysis behind the matrix shape and version choices.

## What changed
- `.github/workflows/ci.yml` &mdash; matrix updated from single `(1.14.1, 25.0.4)` entry to hand-curated `include:` list with two entries: floor and latest stable.

## What stays the same
- All CI steps (`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix test`, `mix dialyzer`) run unchanged on both slots.
- `mix.exs` floor remains `~> 1.14` &mdash; matches CI floor, consistent with Ecto's pattern.
- No source code changes.

## Prep work
This PR is the third in a series; all blockers for a second matrix slot are now resolved:
- **PR #123** (merged): bumped credo 1.7.11 &rarr; 1.7.18 to compile on 1.19, fixed 4 new credo warnings, moved `:preferred_cli_env` to `def cli` callback, refactored a nesting-depth warning.
- **PR #124** (merged): fixed `Juvet.ViewStateRegistry already started` cross-test contamination that broke 7 `Juvet.Bot.BotTest` tests on 1.19.

## Test plan
Both slots verified locally before pushing:
- **1.14.1 / OTP 25**: `mix compile --warnings-as-errors` clean, `mix credo --strict` clean, `mix test` 701/0/2 (current CI baseline preserved).
- **1.19.5 / OTP 28.3**: `mix compile --warnings-as-errors` clean (juvet code; deps Plug + ExVCR emit upstream warnings that aren't ours), `mix credo --strict` clean, `mix test` 701/0/2.

## Trade-offs
- ~2&times; CI runner-minutes per push (parallel jobs, wall-clock similar).
- Dialyzer PLT cache key includes Elixir + OTP, so the new slot will build its own PLT on first run (~1 extra minute one-time per OTP version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)