### PR TITLE
fix(template): drop attribute when conditional list yields no content

### DIFF
--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -528,11 +528,14 @@ defmodule Juvet.Template do
 
   def eval_map(data, bindings) when is_list(data) do
     if Enum.any?(data, &flattening_marker?/1) do
-      Enum.flat_map(data, fn
-        %{__for__: true} = node -> eval_map(node, bindings)
-        %{__if__: true} = node -> eval_map(node, bindings)
-        item -> [eval_map(item, bindings)]
-      end)
+      result =
+        Enum.flat_map(data, fn
+          %{__for__: true} = node -> eval_map(node, bindings)
+          %{__if__: true} = node -> eval_map(node, bindings)
+          item -> [eval_map(item, bindings)]
+        end)
+
+      if result == [], do: nil, else: result
     else
       Enum.map(data, &eval_map(&1, bindings))
     end
@@ -558,6 +561,14 @@ defmodule Juvet.Template do
   end
 
   def eval_map(data, _bindings), do: data
+
+  @doc false
+  def drop_nil_values(map) when is_map(map) do
+    Enum.reduce(map, %{}, fn
+      {_k, nil}, acc -> acc
+      {k, v}, acc -> Map.put(acc, k, v)
+    end)
+  end
 
   @doc false
   def flatten_results(results) do
@@ -832,7 +843,11 @@ defmodule Juvet.Template do
         {Macro.escape(k), compiled_to_quoted(v, bindings_var)}
       end)
 
-    {:%{}, [], pairs}
+    map_ast = {:%{}, [], pairs}
+
+    quote do
+      Juvet.Template.drop_nil_values(unquote(map_ast))
+    end
   end
 
   defp compiled_to_quoted(list, bindings_var) when is_list(list) do
@@ -862,7 +877,10 @@ defmodule Juvet.Template do
           |> Enum.flat_map(&chunk_to_quoted_segment(&1, bindings_var))
 
         quote do
-          Enum.concat(unquote(segments))
+          case Enum.concat(unquote(segments)) do
+            [] -> nil
+            result -> result
+          end
         end
 
       true ->

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1828,10 +1828,10 @@ defmodule Juvet.TemplateTest do
              ]
     end
 
-    test "if-block with falsy condition renders nothing when else_body is absent" do
+    test "if-block with falsy condition drops the parent attribute when else_body is absent" do
       result = IfBlockTemplates.simple_if(show: false)
 
-      assert result.blocks == []
+      refute Map.has_key?(result, :blocks)
     end
 
     test "if-else with truthy condition renders then_body" do
@@ -1863,6 +1863,96 @@ defmodule Juvet.TemplateTest do
                %{type: "section", text: %{type: "mrkdwn", text: "first"}},
                %{type: "section", text: %{type: "mrkdwn", text: "third"}}
              ]
+    end
+  end
+
+  describe "empty conditional lists drop the parent attribute" do
+    defmodule EmptyConditionalListTemplates do
+      use Juvet.Template
+
+      template(:checkboxes_all_false, """
+      :slack.view
+        type: :modal
+        blocks:
+          .input
+            block_id: "opts"
+            label: "Options"
+            element:
+              .checkboxes
+                action_id: "opts"
+                options:
+                  .option{text: "A", value: "a"}
+                  .option{text: "B", value: "b"}
+                initial_options:
+                  <%= if a_selected do %>
+                    .option{text: "A", value: "a"}
+                  <% end %>
+                  <%= if b_selected do %>
+                    .option{text: "B", value: "b"}
+                  <% end %>
+      """)
+
+      template(:checkboxes_mixed, """
+      :slack.view
+        type: :modal
+        blocks:
+          .input
+            block_id: "opts"
+            label: "Options"
+            element:
+              .checkboxes
+                action_id: "opts"
+                options:
+                  .option{text: "A", value: "a"}
+                  .option{text: "B", value: "b"}
+                initial_options:
+                  <%= if a_selected do %>
+                    .option{text: "A", value: "a"}
+                  <% end %>
+                  <%= if b_selected do %>
+                    .option{text: "B", value: "b"}
+                  <% end %>
+      """)
+
+      template(:for_loop_empty_collection, """
+      :slack.view
+        type: :modal
+        blocks:
+          <%= for item <- items do %>
+            .section{text: "<%= item %>"}
+          <% end %>
+      """)
+    end
+
+    test "all if-block branches false inside a list-valued attribute drops the key" do
+      result =
+        EmptyConditionalListTemplates.checkboxes_all_false(
+          a_selected: false,
+          b_selected: false
+        )
+
+      [input] = result.blocks
+      refute Map.has_key?(input.element, :initial_options)
+    end
+
+    test "mixed if-block branches keep only the matching options" do
+      result =
+        EmptyConditionalListTemplates.checkboxes_mixed(
+          a_selected: false,
+          b_selected: true
+        )
+
+      [input] = result.blocks
+
+      assert input.element.initial_options == [
+               %{text: %{type: "plain_text", text: "B"}, value: "b"}
+             ]
+    end
+
+    test "for-loop over empty collection drops the parent attribute" do
+      result = EmptyConditionalListTemplates.for_loop_empty_collection(items: [])
+
+      refute Map.has_key?(result, :blocks)
     end
   end
 end


### PR DESCRIPTION
## Summary

When a list-valued attribute (e.g. `initial_options:`) contains only `<%= if … %>` / `<%= for … %>` markers and every branch evaluates to nothing, the attribute is now dropped from the compiled payload instead of emitting an empty list. Slack rejects `initial_options: []` (and the equivalent for other list-valued attrs), so omitting the key is the only correct shape.

## Changes

- New helper `Juvet.Template.drop_nil_values/1` removes nil-valued keys from a map.
- `eval_map(list)` returns `nil` when a marker-bearing list flat-maps to `[]`, so the parent map's existing nil-drop kicks in.
- `compiled_to_quoted(list)` wraps the `Enum.concat(...)` AST in `case … do [] -> nil; r -> r end` for the same effect at runtime in the compiled path.
- `compiled_to_quoted(map)` now wraps its emitted `%{}` literal in `Juvet.Template.drop_nil_values/1`, bringing the compiled path into parity with the interpreted path's nil-key semantics.

## Compatibility

- Lists *without* markers (literal `attr: []` written in cheex) are unaffected — they go through the non-marker `Enum.map` branch which preserves `[]`.
- One existing test was updated: the `simple_if` falsy-condition case now asserts key absence (`refute Map.has_key?(result, :blocks)`) instead of `:blocks == []`, matching the intended new behavior.

## Motivation

Caught while integrating juvet into Tatsu's edit-recording modal — a `<%= if poll_option_selected? %>...<% end %>` chain inside `initial_options:` was producing `initial_options: []` and being rejected by Slack. The downstream workaround (`drop_empty_initial_options/1`) can be removed once this lands.

## Test plan

- [x] `mix format --check-formatted` (local)
- [x] `mix credo --strict` (local)
- [x] `mix test` (local — 704 tests, 0 failures, 2 skipped)
- [x] Validate against Tatsu by pointing at `{:juvet, path: "../juvet"}` and removing `drop_empty_initial_options/1` — all 31 modal template tests pass; full Tatsu suite shows no regressions (the 1 failure in `Tatsu.Legacy.Tasks.TaskTest` is pre-existing and unrelated).