### PR TITLE
feat(router): add :if predicate option to route matchers

### DIFF
--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -44,25 +44,25 @@ defmodule Juvet.Router.SlackRouter do
   end
 
   defp find_slack_route(%Route{type: :action, route: action_id} = route, request, _opts) do
-    if action_request?(request, action_id), do: route
+    if action_request?(request, action_id) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(%Route{type: :command, route: command_text} = route, request, _opts) do
-    if command_request?(request, command_text), do: route
+    if command_request?(request, command_text) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(%Route{type: :event, route: event} = route, request, _opts) do
-    if event_request?(request, event), do: route
+    if event_request?(request, event) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(%Route{type: :oauth, route: phase} = route, request, opts) do
     configuration = Keyword.get(opts, :configuration)
 
-    if oauth_request?(request, phase, configuration), do: route
+    if oauth_request?(request, phase, configuration) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(%Route{type: :option_load, route: action_id} = route, request, _opts) do
-    if option_load_request?(request, action_id), do: route
+    if option_load_request?(request, action_id) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(%Route{type: :url_verification} = route, request, _opts) do
@@ -70,7 +70,7 @@ defmodule Juvet.Router.SlackRouter do
   end
 
   defp find_slack_route(%Route{type: :view_closed, route: callback_id} = route, request, _opts) do
-    if view_closed_request?(request, callback_id), do: route
+    if view_closed_request?(request, callback_id) and if_matches?(route, request), do: route
   end
 
   defp find_slack_route(
@@ -78,7 +78,16 @@ defmodule Juvet.Router.SlackRouter do
          request,
          _opts
        ) do
-    if view_submission_request?(request, callback_id), do: route
+    if view_submission_request?(request, callback_id) and if_matches?(route, request), do: route
+  end
+
+  # Evaluates the route's optional `:if` predicate against the request.
+  # When `:if` is absent the route is treated as matching.
+  defp if_matches?(%Route{options: options}, request) do
+    case Keyword.get(options, :if) do
+      nil -> true
+      fun when is_function(fun, 1) -> !!fun.(request)
+    end
   end
 
   @impl Juvet.Router

--- a/lib/juvet/router/slack_router.ex
+++ b/lib/juvet/router/slack_router.ex
@@ -83,8 +83,8 @@ defmodule Juvet.Router.SlackRouter do
 
   # Evaluates the route's optional `:if` predicate against the request.
   # When `:if` is absent the route is treated as matching.
-  defp if_matches?(%Route{options: options}, request) do
-    case Keyword.get(options, :if) do
+  defp if_matches?(route, request) do
+    case Keyword.get(route.options, :if) do
       nil -> true
       fun when is_function(fun, 1) -> !!fun.(request)
     end

--- a/test/juvet/integration/slack_route_if_predicate_test.exs
+++ b/test/juvet/integration/slack_route_if_predicate_test.exs
@@ -1,0 +1,125 @@
+defmodule Juvet.Integration.SlackRouteIfPredicateTest do
+  @moduledoc """
+  Regression test for the route-level `:if` predicate.
+
+  The unit tests in `Juvet.Router.SlackRouterTest` build routes directly
+  via `Route.new/3`, which bypasses the macro / `__before_compile__`
+  path that escapes routes for module storage. This test exercises the
+  macro path end-to-end — defining a router with `use Juvet.Router` and
+  `action(..., if: &Mod.fun/1)` — so that we catch any future change
+  that breaks `Macro.escape`-compatibility of the `:if` value.
+
+  `:if` values must be terms `Macro.escape/1` accepts (function captures
+  like `&Mod.fun/arity` qualify; inline `fn ... end` closures do not).
+  """
+  use ExUnit.Case, async: true
+  use Juvet.PlugHelpers
+  use Juvet.SlackRequestHelpers
+
+  defmodule Matchers do
+    def delete?(request), do: action_value_starts_with?(request, "delete:")
+    def edit?(request), do: action_value_starts_with?(request, "edit:")
+
+    defp action_value_starts_with?(%{raw_params: %{"payload" => payload}}, prefix) do
+      case payload do
+        %{"actions" => [%{"value" => value} | _]} -> String.starts_with?(value, prefix)
+        _ -> false
+      end
+    end
+
+    defp action_value_starts_with?(_request, _prefix), do: false
+  end
+
+  defmodule MyRouter do
+    use Juvet.Router
+
+    alias Juvet.Integration.SlackRouteIfPredicateTest.Matchers
+
+    platform :slack do
+      action("recording_action",
+        to: "juvet.integration.slack_route_if_predicate_test.test#delete",
+        if: &Matchers.delete?/1
+      )
+
+      action("recording_action",
+        to: "juvet.integration.slack_route_if_predicate_test.test#edit",
+        if: &Matchers.edit?/1
+      )
+    end
+  end
+
+  defmodule TestController do
+    def delete(%{pid: pid} = context) do
+      send(pid, :delete_dispatched)
+      {:ok, context}
+    end
+
+    def edit(%{pid: pid} = context) do
+      send(pid, :edit_dispatched)
+      {:ok, context}
+    end
+  end
+
+  defp fixture(value) do
+    payload =
+      %{
+        "type" => "block_actions",
+        "actions" => [%{"action_id" => "recording_action", "value" => value}]
+      }
+      |> Poison.encode!()
+
+    %{"token" => "SLACK_TOKEN", "payload" => payload}
+  end
+
+  describe "with two same-action_id routes gated by :if predicates" do
+    setup do
+      [signing_secret: generate_slack_signing_secret()]
+    end
+
+    test "dispatches to the delete handler when the value matches",
+         %{signing_secret: signing_secret} do
+      params = fixture("delete:poll:42:1")
+
+      conn =
+        request!(
+          :post,
+          "/slack/actions",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      assert conn.halted
+      assert_received :delete_dispatched
+      refute_received :edit_dispatched
+    end
+
+    test "dispatches to the edit handler when the value matches",
+         %{signing_secret: signing_secret} do
+      params = fixture("edit:poll:42:1")
+
+      conn =
+        request!(
+          :post,
+          "/slack/actions",
+          params,
+          slack_headers(params, signing_secret),
+          context: %{pid: self()},
+          configuration: [
+            router: MyRouter,
+            slack: [signing_secret: signing_secret]
+          ]
+        )
+
+      assert conn.status == 200
+      assert conn.halted
+      assert_received :edit_dispatched
+      refute_received :delete_dispatched
+    end
+  end
+end

--- a/test/juvet/router/slack_router_test.exs
+++ b/test/juvet/router/slack_router_test.exs
@@ -51,6 +51,94 @@ defmodule Juvet.Router.SlackRouterTest do
     end
   end
 
+  describe "find_route/2 with :if predicate" do
+    setup do
+      payload = %{
+        "type" => "block_actions",
+        "actions" => [%{"action_id" => "recording_action", "value" => "delete:poll:42:1"}]
+      }
+
+      request = Request.new(%{params: %{"payload" => payload}})
+
+      request = %{
+        request
+        | platform: :slack,
+          verified?: true,
+          raw_params: %{"payload" => payload}
+      }
+
+      [request: request]
+    end
+
+    defp router_with(routes) do
+      {:ok, platform} =
+        Enum.reduce(routes, {:ok, Platform.new(:slack)}, fn route, {:ok, acc} ->
+          Platform.put_route(acc, route)
+        end)
+
+      SlackRouter.new(platform)
+    end
+
+    defp action_value_starts_with?(prefix) do
+      fn %{raw_params: %{"payload" => payload}} ->
+        %{"actions" => [%{"value" => value} | _]} = payload
+        String.starts_with?(value, prefix)
+      end
+    end
+
+    test "matches when the :if predicate returns true", %{request: request} do
+      route =
+        Route.new(:action, "recording_action",
+          to: "controller#delete",
+          if: action_value_starts_with?("delete:")
+        )
+
+      router = router_with([route])
+
+      assert {:ok, matched} = SlackRouter.find_route(router, request)
+      assert matched.options[:to] == "controller#delete"
+    end
+
+    test "does not match when the :if predicate returns false", %{request: request} do
+      route =
+        Route.new(:action, "recording_action",
+          to: "controller#edit",
+          if: action_value_starts_with?("edit:")
+        )
+
+      router = router_with([route])
+
+      assert {:error, {:unknown_route, _}} = SlackRouter.find_route(router, request)
+    end
+
+    test "falls through to the next route when an earlier :if fails", %{request: request} do
+      edit_route =
+        Route.new(:action, "recording_action",
+          to: "controller#edit",
+          if: action_value_starts_with?("edit:")
+        )
+
+      delete_route =
+        Route.new(:action, "recording_action",
+          to: "controller#delete",
+          if: action_value_starts_with?("delete:")
+        )
+
+      router = router_with([edit_route, delete_route])
+
+      assert {:ok, matched} = SlackRouter.find_route(router, request)
+      assert matched.options[:to] == "controller#delete"
+    end
+
+    test "routes without :if are unaffected", %{request: request} do
+      route = Route.new(:action, "recording_action", to: "controller#any")
+      router = router_with([route])
+
+      assert {:ok, matched} = SlackRouter.find_route(router, request)
+      assert matched.options[:to] == "controller#any"
+    end
+  end
+
   describe "request_format/1" do
     test "returns :message when the payload has a message request" do
       payload = %{


### PR DESCRIPTION
## Summary

Routes can now take an `:if` keyword option whose value is a 1-arity **function capture** (`&Mod.fun/1`) that receives the `Juvet.Router.Request.t()`. The route only matches when **both** the existing type/route_key check passes **and** the predicate returns a truthy value. Absent `:if` preserves current behavior.

## Motivation

From the [Tatsu PR #143 gap notes](https://github.com/tatsuio/tatsu/pull/143): Juvet routes can't express dispatch logic based on the request payload. Tatsu works around this by encoding multiple semantic dimensions into a single action value (e.g. `"delete:poll:42:1"`) and parsing them inside the controller (`DashboardController.recording_action/1`). With `:if`, the dispatch lives at the route level where it belongs:

```elixir
action "recording_action", to: "controller#delete", if: &Matchers.delete?/1
action "recording_action", to: "controller#edit",   if: &Matchers.edit?/1
```

The Tatsu controller can then collapse from a `case String.split(value, ":")` dispatcher to direct handler functions per route — see the validation PR [tatsuio/tatsu#149](https://github.com/tatsuio/tatsu/pull/149).

## Scope

The predicate hook is added to every Slack route type that takes a user-defined route: `action`, `command`, `event`, `oauth`, `option_load`, `view_closed`, `view_submission`. `url_verification` is unaffected (no user-supplied predicate surface).

Route order is preserved — predicates are evaluated in declaration order, and the first matching route wins. `:if` is fully additive to existing routing semantics.

## API contract

The `:if` value must be a **function capture** of arity 1 (`&Mod.fun/1`) — not an inline `fn ... end` closure. This is a hard constraint of how Juvet stores routes: in `Juvet.Router.__before_compile__`, the accumulated platform / routes state is emitted into `__platforms__/0` via `Macro.escape/1`, which only accepts escapable terms (literals, captures, etc., per the `Macro.escape/2` docs). Closures are not escapable and would raise `ArgumentError` at compile time.

```elixir
# ✓ Works
defmodule MyApp.Bot.Matchers do
  def delete_value?(request) do
    case request.raw_params["payload"] do
      %{"actions" => [%{"value" => v} | _]} -> String.starts_with?(v, "delete:")
      _ -> false
    end
  end
end

action "recording_action", to: "controller#delete", if: &MyApp.Bot.Matchers.delete_value?/1

# ✗ Raises at compile time — closures aren't Macro.escape-compatible
action "recording_action", to: "controller#delete",
       if: fn req -> ... end
```

Architecture note: route matching runs before middleware enrichment, so a richer 'context' (with `current_user` / `current_team`) isn't available at this layer and shouldn't be — that's Phoenix/Rails route-constraint precedent. Dispatch on user/team belongs in middleware or controller branching.

## Changes

- `if_matches?/2` helper in `slack_router.ex` (6 lines)
- Threaded through 7 `find_slack_route/3` clauses with `and if_matches?(route, request)`
- 4 unit tests in `slack_router_test.exs` (predicate true, predicate false, fallthrough to next route, route without `:if` unchanged) — these construct routes via `Route.new/3` directly
- **Integration regression test** in `slack_route_if_predicate_test.exs` exercising the **macro path** (`use Juvet.Router` + `action(..., if: &Mod.fun/1)`) end-to-end through the plug pipeline, so future changes that break `Macro.escape`-compatibility of `:if` will fail loudly

Diff: `+229 / -9` (most of that is the regression test).

## Compatibility

- Strict superset of current behavior — routes without `:if` are unchanged.
- No new dependencies, no API changes to existing route macros.
- Function arity is enforced (`is_function(fun, 1)`) — passing a non-1-arity callable will raise at match time rather than silently misbehave.

## Test plan

- [x] `mix format --check-formatted` (local)
- [x] `mix credo --strict` (local)
- [x] `mix test` (local — 710 tests, 0 failures, 2 skipped)
- [x] Validate against Tatsu by collapsing `recording_action/1` into multiple routed handlers — see [tatsuio/tatsu#149](https://github.com/tatsuio/tatsu/pull/149). 24 dashboard controller tests pass, full Tatsu suite shows no regressions (the 1 failure in `Tatsu.Legacy.Tasks.TaskTest` is pre-existing and unrelated).