### PR TITLE
fix(view_state): return raw action for unknown input types instead of FunctionClauseError

### DIFF
--- a/lib/juvet/slack_view_state.ex
+++ b/lib/juvet/slack_view_state.ex
@@ -27,4 +27,9 @@ defmodule Juvet.SlackViewState do
   end
 
   defp form_value(%{"value" => value}), do: value
+
+  # Catch-all for input types we don't yet extract — preserves the raw action
+  # so callers can introspect (`is_map(value)` signals "unhandled type") rather
+  # than crash with FunctionClauseError.
+  defp form_value(action), do: action
 end

--- a/test/juvet/slack_view_state_test.exs
+++ b/test/juvet/slack_view_state_test.exs
@@ -70,6 +70,24 @@ defmodule Juvet.SlackViewStateTest do
              }
     end
 
+    test "returns the raw action for input types without a dedicated extractor" do
+      view_state = %{
+        "block_id" => %{
+          "rich_text_field" => %{
+            "type" => "rich_text_input",
+            "rich_text_value" => %{"type" => "rich_text", "elements" => []}
+          }
+        }
+      }
+
+      assert SlackViewState.parse(view_state) == %{
+               "rich_text_field" => %{
+                 "type" => "rich_text_input",
+                 "rich_text_value" => %{"type" => "rich_text", "elements" => []}
+               }
+             }
+    end
+
     test "handles multiple fields under one block" do
       view_state = %{
         "block_id_1" => %{


### PR DESCRIPTION
## Summary

`Juvet.SlackViewState.parse/1` routes each action through `form_value/1`, which has explicit clauses for the Slack input types Juvet has seen so far (`selected_date`, `selected_time`, `selected_option`, `selected_options`, `selected_conversation`, `value`). Unknown types — `rich_text_input`, `datetimepicker`, `multi_users_select`, `multi_channels_select`, `users_select`, etc. — were raising `FunctionClauseError` at runtime.

## Change

One additional clause at the bottom of `form_value/1` that returns the raw action map verbatim. Callers can introspect the unhandled type via `is_map/1` rather than catching the exception.

```elixir
defp form_value(action), do: action
```

## Compatibility

Strict superset of current behavior:

- All previously-covered types still return the same extracted scalar / list.
- Previously-uncovered types stop crashing — they now appear as `%{action_id => raw_action_map}` in the result.

## Test plan

- [x] `mix format --check-formatted` (local)
- [x] `mix credo --strict` (local)
- [x] `mix test` (local — 711 tests, 0 failures, 2 skipped)
- [x] Added a unit test for an unknown type (`rich_text_input`) asserting the raw action shape survives

## Motivation

Surfaced while planning the Tatsu migration from inline view-state flattening to `SlackViewState.parse/1` (Tatsu PR #143 gap #5). Tatsu's current input types are all covered by existing extractors, but a forward-compat safety net here means future input types won't silently crash modal submissions.