### PR TITLE
refactor(controller): move SlackViewState into Juvet.Controller namespace + expose via parse_view_state/1

### DIFF
--- a/lib/juvet/controller.ex
+++ b/lib/juvet/controller.ex
@@ -5,8 +5,18 @@ defmodule Juvet.Controller do
 
   @view_context_key :juvet_view
 
+  alias Juvet.Controller.SlackViewState
   alias Juvet.Router.{Conn, Request, Response, RouterFactory}
   alias Juvet.{View, ViewStateManager}
+
+  @doc """
+  Extracts a flat `%{action_id => value}` map from a Slack view submission's
+  `state.values`. See `Juvet.Controller.SlackViewState` for the per-input-type
+  extraction rules.
+
+  Imported into modules that `use Juvet.Controller`.
+  """
+  defdelegate parse_view_state(view_state), to: SlackViewState, as: :parse
 
   defmacro __using__(opts) do
     quote do

--- a/lib/juvet/controller/slack_view_state.ex
+++ b/lib/juvet/controller/slack_view_state.ex
@@ -1,4 +1,4 @@
-defmodule Juvet.SlackViewState do
+defmodule Juvet.Controller.SlackViewState do
   @moduledoc """
   Functions to operate on Slack's view responses and the view state passed back.
   """

--- a/test/juvet/controller/slack_view_state_test.exs
+++ b/test/juvet/controller/slack_view_state_test.exs
@@ -1,7 +1,7 @@
-defmodule Juvet.SlackViewStateTest do
+defmodule Juvet.Controller.SlackViewStateTest do
   use ExUnit.Case, async: true
 
-  alias Juvet.SlackViewState
+  alias Juvet.Controller.SlackViewState
 
   describe "parse/1" do
     test "returns a map of keys and values parsed from Slack's conversation select" do

--- a/test/juvet/controller_test.exs
+++ b/test/juvet/controller_test.exs
@@ -27,9 +27,12 @@ defmodule Juvet.ControllerTest do
     def send_response_test(context, response \\ nil), do: send_response(context, response)
 
     def update_response_test(context, response), do: update_response(context, response)
+
+    def parse_view_state_test(view_state), do: parse_view_state(view_state)
   end
 
   alias Controllers.MyController
+  alias Juvet.Controller.SlackViewState
   alias Juvet.Router.{Request, Response}
 
   describe "controller_prefix/1" do
@@ -104,6 +107,30 @@ defmodule Juvet.ControllerTest do
       view_state = MyController.view_state()
 
       assert view_state == Juvet.ViewStateManager
+    end
+  end
+
+  describe "parse_view_state/1" do
+    test "is imported into modules that use Juvet.Controller" do
+      view_state = %{
+        "block_id" => %{
+          "question" => %{"type" => "plain_text_input", "value" => "What's up?"}
+        }
+      }
+
+      assert MyController.parse_view_state_test(view_state) == %{
+               "question" => "What's up?"
+             }
+    end
+
+    test "delegates to Juvet.Controller.SlackViewState.parse/1" do
+      view_state = %{
+        "block_id" => %{
+          "date_field" => %{"type" => "datepicker", "selected_date" => "2026-06-15"}
+        }
+      }
+
+      assert Juvet.Controller.parse_view_state(view_state) == SlackViewState.parse(view_state)
     end
   end
 


### PR DESCRIPTION
## Summary

Surface the view-state flattening helper at the layer where it's used.

Two Tatsu controllers (and likely others) reinvented a less-complete version of `Juvet.SlackViewState.parse/1` inline because the canonical helper was hard to find from a controller — its module name read like an internal model rather than a controller utility. This PR moves the file under the `Juvet.Controller` namespace and adds a delegate so the function is in scope automatically inside any module that does `use Juvet.Controller`.

## Changes

**Moves:**
- `lib/juvet/slack_view_state.ex` → `lib/juvet/controller/slack_view_state.ex`
- `test/juvet/slack_view_state_test.exs` → `test/juvet/controller/slack_view_state_test.exs`
- Module `Juvet.SlackViewState` → `Juvet.Controller.SlackViewState`

**New surface on `Juvet.Controller`:**

```elixir
defdelegate parse_view_state(view_state), to: SlackViewState, as: :parse
```

Combined with the existing prelude (`import unquote(__MODULE__)`), this means any module using `Juvet.Controller` can call `parse_view_state(view["state"]["values"])` directly — no alias or module reference needed.

## Why this naming

Two existing conventions in the codebase:

| Pattern | Examples |
|---|---|
| Flat `Slack<Thing>` | `Juvet.Router.SlackRouter`, `Juvet.Router.SlackRouteHandler`, `Juvet.SlackAPI` |
| Nested `Slack.<Thing>` | `Juvet.Template.Compiler.Slack.View`, `Juvet.Template.Compiler.Slack.Header`, etc. |

The nested form is justified in Template.Compiler because it has many Slack-specific children. `Juvet.Controller` has one Slack thing for the foreseeable future, so the Router precedent fits: **flat `Juvet.Controller.SlackViewState`**. When/if Discord lands, both platforms can move to nested `<Platform>.` namespaces in a single migration.

## Compatibility

This is a hard rename — no deprecated shim at `Juvet.SlackViewState`. Juvet is pre-1.0 (README says "WORK IN PROGRESS AND NOT READY FOR ANYTHING REAL YET"); the only known external consumer is Tatsu, which will migrate alongside this change.

## Coordination with #128

[#128](https://github.com/juvet/juvet/pull/128) (form_value catch-all) and this PR touch the same module but disjoint lines. Whichever lands second rebases trivially. The follow-up Tatsu migration depends on both being merged.

## Test plan

- [x] `mix format --check-formatted` (local)
- [x] `mix credo --strict` (local)
- [x] `mix test` (local — 712 tests, 0 failures, 2 skipped)
- [x] Added a test verifying `parse_view_state/1` is imported into modules using `Juvet.Controller`
- [x] Added a test verifying the delegate target matches `Juvet.Controller.SlackViewState.parse/1`