### PR TITLE
docs: document Elixir/OTP version support policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Documented the Elixir/OTP version support policy: Juvet supports Elixir ~> 1.14
+  on OTP 25+, with CI testing both the supported floor and the latest stable
+  Elixir/OTP pair (the latter with `--warnings-as-errors`). Raising the floor is
+  treated as a breaking change and will only happen in a new minor version.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ If you or your company will benefit from a well-maintained and easy to use chat 
 
 Thank you for the support! :heartbeat:
 
+## SUPPORTED VERSIONS
+
+Juvet requires **Elixir ~> 1.14** and **Erlang/OTP 25+**.
+
+Every change is tested in CI against two version pairs:
+
+* the oldest supported pair (Elixir 1.14 / OTP 25), so the declared floor is always proven to work
+* the latest stable pair (currently Elixir 1.19 / OTP 28), with `--warnings-as-errors`, so consumers on newer Elixir never see compiler warnings from Juvet
+
+Raising the Elixir floor is considered a breaking change; it will only happen in a new minor version and will be called out in the [CHANGELOG](CHANGELOG.md).
+
 ## INSTALLATION
 
 * Add the Juvet dependencies to your `mix.exs` file


### PR DESCRIPTION
## Why

Flagged after PR #122: warnings tightened in Elixir 1.16+ (e.g. `defp` clause grouping) were silent on Juvet's 1.14-only CI but surfaced for downstream consumers running newer Elixir, tripping their `--warnings-as-errors` setups.

The CI side was fixed in fb78009 (added an Elixir 1.19.5 / OTP 28 slot with `--warnings-as-errors`), but the support policy itself was never written down. This PR records the decision.

## The policy

- **Floor stays at Elixir ~> 1.14 / OTP 25** — it matches `mix.exs`, CI proves it works, and keeping it costs nothing while any pinned consumer might still depend on it. This mirrors Ecto's approach (Req/Phoenix/Plug have moved to ~> 1.15; we can follow when 1.14 actually blocks something).
- **CI always tests two pairs**: the floor and the latest stable, the latter with `--warnings-as-errors`, so newer-Elixir warnings fail here before consumers see them.
- **Raising the floor is a breaking change**, reserved for a new minor version and called out in the CHANGELOG.

## Changes

- New SUPPORTED VERSIONS section in the README
- New `CHANGELOG.md` (Keep a Changelog format) seeded with an Unreleased entry, ready for the overdue 0.7.0 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)