### PR TITLE
feat(compiler): support conditional initial_option in selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cheex templates can now conditionally render a select's or radio button group's
+  `initial_option` with `<%= if %>` around the option child. The slot resolves to
+  a single object when the condition is true and is omitted entirely when false,
+  matching what Slack expects; previously this crashed at template compile time.
+  ([#132](https://github.com/juvet/juvet/pull/132))
 - Documented the Elixir/OTP version support policy: Juvet supports Elixir ~> 1.14
   on OTP 25+, with CI testing both the supported floor and the latest stable
   Elixir/OTP pair (the latter with `--warnings-as-errors`). Raising the floor is

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -517,6 +517,20 @@ defmodule Juvet.Template do
     flat_eval_body(body, bindings)
   end
 
+  # Singular-slot conditional (e.g. a select's `initial_option`). Unlike `__if__`,
+  # which flattens into a list, this collapses an `if`-wrapped 0-or-1 child to a
+  # single object (condition true) or `nil` (false). A `nil` value is dropped by
+  # the map branch below, so the slot key is omitted entirely — which is what
+  # Slack requires for an absent `initial_option`.
+  def eval_map(%{__if_single__: true} = node, bindings) do
+    {result, _} = Code.eval_string(node.condition, bindings)
+
+    case if(result, do: node.then, else: node.else) do
+      nil -> nil
+      element -> eval_map(element, bindings)
+    end
+  end
+
   def eval_map(data, bindings) when is_map(data) do
     Enum.reduce(data, %{}, fn {k, v}, acc ->
       case eval_map(v, bindings) do
@@ -837,6 +851,26 @@ defmodule Juvet.Template do
     end
   end
 
+  # Singular-slot conditional (mirrors the `%{__if_single__: true}` eval_map/2
+  # clause for the compiled-to-quoted path). Yields the single `then`/`else`
+  # element or `nil` — not the list `__if__` produces. A `nil` result is dropped
+  # by the surrounding `drop_nil_values/1`, omitting the slot key entirely.
+  defp compiled_to_quoted(%{__if_single__: true} = node, bindings_var) do
+    condition = node.condition
+    then_quoted = single_branch_quoted(node.then, bindings_var)
+    else_quoted = single_branch_quoted(node.else, bindings_var)
+
+    quote do
+      {__if_single_result__, _} = Code.eval_string(unquote(condition), unquote(bindings_var))
+
+      if __if_single_result__ do
+        unquote(then_quoted)
+      else
+        unquote(else_quoted)
+      end
+    end
+  end
+
   defp compiled_to_quoted(map, bindings_var) when is_map(map) do
     pairs =
       Enum.map(map, fn {k, v} ->
@@ -899,6 +933,11 @@ defmodule Juvet.Template do
   end
 
   defp compiled_to_quoted(value, _bindings_var), do: Macro.escape(value)
+
+  # Quotes a single `__if_single__` branch element (or nil when the branch is
+  # absent), deferring its EEx string evaluation to runtime.
+  defp single_branch_quoted(nil, _bindings_var), do: nil
+  defp single_branch_quoted(element, bindings_var), do: compiled_to_quoted(element, bindings_var)
 
   # Builds a quoted expression that evaluates an if-block body (then or else)
   # against the bindings at runtime.

--- a/lib/juvet/template/compiler/slack.ex
+++ b/lib/juvet/template/compiler/slack.ex
@@ -148,4 +148,23 @@ defmodule Juvet.Template.Compiler.Slack do
 
   defp compile_else_body(nil), do: nil
   defp compile_else_body(list) when is_list(list), do: Enum.map(list, &compile_element/1)
+
+  @doc false
+  # Compiles an `if_block` that occupies a *singular* slot (e.g. a select's
+  # `initial_option`) into an `__if_single__` marker. The regular `__if__`
+  # marker resolves to a list at eval time, which is correct for list slots
+  # (`options`, `initial_options`) but wrong for a slot that must hold a single
+  # object or be omitted. `__if_single__` is resolved by `Juvet.Template.eval_map/2`.
+  def compile_single_if(%{node_type: :if_block} = node) do
+    %{
+      __if_single__: true,
+      condition: node.condition,
+      then: single_branch(node.then_body),
+      else: single_branch(node.else_body)
+    }
+  end
+
+  defp single_branch(nil), do: nil
+  defp single_branch([]), do: nil
+  defp single_branch([element | _]), do: compile_element(element)
 end

--- a/lib/juvet/template/compiler/slack/elements/radio_buttons.ex
+++ b/lib/juvet/template/compiler/slack/elements/radio_buttons.ex
@@ -22,7 +22,12 @@ defmodule Juvet.Template.Compiler.Slack.Elements.RadioButtons do
 
   defp put_options(map, _), do: map
 
-  defp put_initial_option(map, %{children: %{initial_option: opt}}),
+  defp put_initial_option(map, %{
+         children: %{initial_option: [%{node_type: :if_block} = if_block]}
+       }),
+       do: Map.put(map, :initial_option, Slack.compile_single_if(if_block))
+
+  defp put_initial_option(map, %{children: %{initial_option: opt}}) when is_map(opt),
     do: Map.put(map, :initial_option, Slack.compile_element(opt))
 
   defp put_initial_option(map, _), do: map

--- a/lib/juvet/template/compiler/slack/elements/select.ex
+++ b/lib/juvet/template/compiler/slack/elements/select.ex
@@ -117,8 +117,10 @@ defmodule Juvet.Template.Compiler.Slack.Elements.Select do
 
   # Conditionally-included child: `child_value/1` wraps an `<%= if %>`-guarded
   # option as `[if_block]`. Collapse it to a single-object-or-omitted slot.
-  defp compile_initial_option(%{children: %{initial_option: [%{node_type: :if_block} = if_block]}}),
-    do: Slack.compile_single_if(if_block)
+  defp compile_initial_option(%{
+         children: %{initial_option: [%{node_type: :if_block} = if_block]}
+       }),
+       do: Slack.compile_single_if(if_block)
 
   defp compile_initial_option(%{children: %{initial_option: opt}}) when is_map(opt),
     do: Slack.compile_element(opt)

--- a/lib/juvet/template/compiler/slack/elements/select.ex
+++ b/lib/juvet/template/compiler/slack/elements/select.ex
@@ -115,7 +115,12 @@ defmodule Juvet.Template.Compiler.Slack.Elements.Select do
     maybe_put(map, :initial_option, compile_initial_option(el))
   end
 
-  defp compile_initial_option(%{children: %{initial_option: opt}}),
+  # Conditionally-included child: `child_value/1` wraps an `<%= if %>`-guarded
+  # option as `[if_block]`. Collapse it to a single-object-or-omitted slot.
+  defp compile_initial_option(%{children: %{initial_option: [%{node_type: :if_block} = if_block]}}),
+    do: Slack.compile_single_if(if_block)
+
+  defp compile_initial_option(%{children: %{initial_option: opt}}) when is_map(opt),
     do: Slack.compile_element(opt)
 
   defp compile_initial_option(_), do: nil

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -1109,6 +1109,118 @@ defmodule Juvet.TemplateTest do
     end
   end
 
+  describe "conditional initial_option inside a select" do
+    defmodule ConditionalInitialOptionTemplates do
+      use Juvet.Template
+
+      template(:select_with_conditional_initial_option, """
+      :slack.view
+        type: :home
+        blocks:
+          .actions
+            elements:
+              .select
+                source: :external
+                action_id: "sched"
+                initial_option:
+                  <%= if preset do %>
+                  .option{text: "<%= preset.text %>", value: "<%= preset.value %>"}
+                  <% end %>
+      """)
+    end
+
+    test "renders a single initial_option object when the condition is true" do
+      result =
+        ConditionalInitialOptionTemplates.select_with_conditional_initial_option(
+          preset: %{text: "By Friday", value: "by_fri"}
+        )
+
+      [actions] = result.blocks
+      [select] = actions.elements
+
+      assert select.type == "external_select"
+      assert select.action_id == "sched"
+
+      assert select.initial_option == %{
+               text: %{type: "plain_text", text: "By Friday"},
+               value: "by_fri"
+             }
+    end
+
+    test "omits the initial_option key entirely when the condition is false" do
+      result =
+        ConditionalInitialOptionTemplates.select_with_conditional_initial_option(preset: nil)
+
+      [actions] = result.blocks
+      [select] = actions.elements
+
+      assert select.type == "external_select"
+      assert select.action_id == "sched"
+      refute Map.has_key?(select, :initial_option)
+    end
+  end
+
+  # A select with BOTH a for-loop (`options`) and a conditional `initial_option`
+  # forces the `compiled_to_quoted` path (the template contains `__for__`/`__if__`
+  # markers), as opposed to the `eval_map` runtime path above. Both paths must
+  # collapse the singular `__if_single__` slot identically.
+  describe "conditional initial_option alongside dynamic options" do
+    defmodule ConditionalInitialOptionWithLoopTemplates do
+      use Juvet.Template
+
+      template(:select_with_options_and_conditional_initial_option, """
+      :slack.view
+        type: :home
+        blocks:
+          .actions
+            elements:
+              .select
+                source: :static
+                action_id: "proj"
+                options:
+                  <%= for opt <- options do %>
+                  .option{text: "<%= opt.name %>", value: "<%= opt.id %>"}
+                  <% end %>
+                initial_option:
+                  <%= if preset do %>
+                  .option{text: "<%= preset.name %>", value: "<%= preset.id %>"}
+                  <% end %>
+      """)
+    end
+
+    test "renders a single initial_option object when the condition is true" do
+      result =
+        ConditionalInitialOptionWithLoopTemplates.select_with_options_and_conditional_initial_option(
+          options: [%{id: 1, name: "Alpha"}, %{id: 2, name: "Beta"}],
+          preset: %{id: 2, name: "Beta"}
+        )
+
+      [actions] = result.blocks
+      [select] = actions.elements
+
+      assert length(select.options) == 2
+
+      assert select.initial_option == %{
+               text: %{type: "plain_text", text: "Beta"},
+               value: "2"
+             }
+    end
+
+    test "omits the initial_option key entirely when the condition is false" do
+      result =
+        ConditionalInitialOptionWithLoopTemplates.select_with_options_and_conditional_initial_option(
+          options: [%{id: 1, name: "Alpha"}],
+          preset: nil
+        )
+
+      [actions] = result.blocks
+      [select] = actions.elements
+
+      assert length(select.options) == 1
+      refute Map.has_key?(select, :initial_option)
+    end
+  end
+
   describe "for-loop with JSON format" do
     defmodule ForLoopJsonTemplates do
       use Juvet.Template, format: :json


### PR DESCRIPTION
## Summary

A select's `initial_option` is a **singular** slot — Slack wants a single object or the key omitted. Authoring it conditionally in cheex (`<%= if %>` around the `.option` child) lowered to `[if_block]`, which `compile_initial_option/1` passed to `Slack.compile_element/1` with no list clause — a **compile-time crash**. The plural `initial_options` slot avoided this only because it maps over its children and the list branch flattens the `__if__` marker.

This adds an `__if_single__` marker that collapses an if-wrapped 0-or-1 child to a single object (condition true) or `nil` (false). A `nil` value is dropped by the surrounding map walk / `drop_nil_values`, so the slot key is omitted — exactly what Slack requires for an absent `initial_option`.

## Why two pipelines

The marker is resolved in **both** evaluation paths:
- `eval_map/2` — the runtime walk used when a template has no other dynamic markers.
- `compiled_to_quoted/2` — the quoted path used when the template *also* contains `__for__`/`__if__` markers (e.g. a select with both a `for`-loop `options:` list and a conditional `initial_option:`). Missing this path was a silent bug: the then-branch evaluated unconditionally.

## Changes

- `Slack.compile_single_if/1` builds the `__if_single__` marker from an `if_block` node.
- `compile_initial_option/1` (select) and `put_initial_option/1` (radio_buttons) detect the `[if_block]` shape and emit it.
- `eval_map/2` and `compiled_to_quoted/2` each gain an `__if_single__` clause.

## Tests

End-to-end render tests cover the present and omitted cases through **both** pipelines (725 tests, 0 failures).

## Context

Resolves the long-standing cheex `initial_option` conditional gotcha. Consumed by Tatsu's edit-recording modal, where it replaces a post-render `initial_option`-injection workaround (validated locally: 33 template tests pass with the workaround removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)