### PR TITLE
fix(view_state): don't return dead pids from ViewStateRegistry lookups

### DIFF
--- a/lib/juvet/view_state_registry.ex
+++ b/lib/juvet/view_state_registry.ex
@@ -61,8 +61,21 @@ defmodule Juvet.ViewStateRegistry do
     {:stop, :normal, state, state}
   end
 
+  # A registered process can die before its :DOWN message is processed, so a
+  # lookup in that window would hand out a dead pid. Treat it as unregistered
+  # and clean up eagerly.
   def handle_call({:whereis_name, name}, _from, state) do
-    {:reply, state |> find_by_name(name), state}
+    case state |> find_by_name(name) do
+      :undefined ->
+        {:reply, :undefined, state}
+
+      pid ->
+        if Process.alive?(pid) do
+          {:reply, pid, state}
+        else
+          {:reply, :undefined, state |> Map.delete(name)}
+        end
+    end
   end
 
   def handle_cast({:unregister_name, name}, state) do

--- a/test/juvet/view_state_registry_test.exs
+++ b/test/juvet/view_state_registry_test.exs
@@ -50,6 +50,30 @@ defmodule Juvet.ViewStateRegistryTest do
     end
   end
 
+  describe "whereis_name/1" do
+    setup do
+      start_supervised(ViewStateRegistry)
+      on_exit(&shut_down_registry/0)
+      :ok
+    end
+
+    test "returns :undefined for a dead process even before its :DOWN is processed" do
+      name = {:stale, :key}
+
+      pid = spawn(fn -> nil end)
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}
+
+      # Inject the stale entry directly, simulating a lookup that races the
+      # registry's own :DOWN handling for the dead process.
+      :sys.replace_state(Process.whereis(ViewStateRegistry.name()), fn state ->
+        Map.put(state, name, pid)
+      end)
+
+      assert :undefined = ViewStateRegistry.whereis_name(name)
+    end
+  end
+
   describe "send/2" do
     setup do
       start_supervised(ViewStateRegistry)


### PR DESCRIPTION
## Why

PR #132's CI fails on the Elixir 1.19.5 / OTP 28 slot with a single unrelated test failure:

```
1) test exists?/1 returns false if the view state does not exists via key (Juvet.ViewStateTest)
   ** (exit) exited in: GenServer.call({:via, Juvet.ViewStateRegistry, {:my, :unique, :key}}, :exists?, 5000)
       ** (EXIT) no process
```

It reproduced on a re-run with a different seed, so it isn't flake — it's a latent race that 1.19.5/OTP 28 scheduling exposes consistently:

1. `ViewStateRegistry` only removes an entry when it processes the `:DOWN` monitor message for a registered process.
2. `ViewState.exists?/1` calls `whereis_name/1` first; in the window between process death and `:DOWN` handling it gets the stale pid back.
3. It then `GenServer.call`s the dead pid and exits with `:noproc` instead of returning `false`.

The existing test "removes the name when the process dies" relies on winning the same race (kill, then immediately `whereis_name`).

## Fix

`whereis_name` now checks `Process.alive?/1` at lookup time: a dead pid is reported as `:undefined` and its entry is dropped eagerly instead of waiting for the `:DOWN` message. This fixes every lookup path through the registry (`exists?`, `via` resolution, `send/2`) at the source.

Includes a deterministic regression test that injects a stale entry via `:sys.replace_state/2`, simulating a lookup that races the `:DOWN` handling.

Once this merges, #132 just needs a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)