### PR TITLE
feat(slack_api): surface Retry-After on rate-limited (429) responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Juvet.SlackAPI` now surfaces rate limiting: a Slack `HTTP 429` response is
+  parsed into an `ok: false` body with `error: "ratelimited"` and a
+  `retry_after` value (seconds) read from the `Retry-After` header, so callers
+  can back off for the duration Slack requests instead of treating it as an
+  opaque parse error.
 - Cheex templates can now conditionally render a select's or radio button group's
   `initial_option` with `<%= if %>` around the option child. The slot resolves to
   a single object when the condition is true and is omitted entirely when false,

--- a/lib/juvet/slack_api.ex
+++ b/lib/juvet/slack_api.ex
@@ -20,10 +20,22 @@ defmodule Juvet.SlackAPI do
     {:ok, body}
   end
 
+  # Default seconds to wait when Slack returns a 429 without a parseable
+  # `Retry-After` header (Slack always sends one, but be defensive).
+  @default_retry_after 30
+
   @doc """
   Decodes a JSON response and converts it into a Map.
+
+  A Slack rate-limited response (HTTP 429) is surfaced as an `ok: false` body
+  with `error: "ratelimited"` and a `retry_after` value (seconds) read from the
+  `Retry-After` header, so callers can back off for the duration Slack asks for.
   """
   @spec parse_response({:ok, HTTPoison.Response.t()}) :: {:ok, map()} | {:error, Exception.t()}
+  def parse_response({:ok, %HTTPoison.Response{status_code: 429, headers: headers}}) do
+    {:ok, %{ok: false, error: "ratelimited", retry_after: retry_after(headers)}}
+  end
+
   def parse_response({:ok, %HTTPoison.Response{body: body}}) do
     Poison.decode(body, keys: :atoms)
   end
@@ -58,6 +70,25 @@ defmodule Juvet.SlackAPI do
       params,
       headers(access_token)
     )
+  end
+
+  @doc false
+  defp retry_after(headers) do
+    headers
+    |> Enum.find_value(fn {key, value} ->
+      if String.downcase(key) == "retry-after", do: value
+    end)
+    |> parse_retry_after()
+  end
+
+  @doc false
+  defp parse_retry_after(nil), do: @default_retry_after
+
+  defp parse_retry_after(value) do
+    case Integer.parse(value) do
+      {seconds, _rest} when seconds > 0 -> seconds
+      _ -> @default_retry_after
+    end
   end
 
   @doc false

--- a/test/juvet/slack_api_test.exs
+++ b/test/juvet/slack_api_test.exs
@@ -1,0 +1,62 @@
+defmodule Juvet.SlackAPITest do
+  use ExUnit.Case, async: true
+
+  alias Juvet.SlackAPI
+
+  describe "parse_response/1" do
+    test "decodes a JSON body into an atom-keyed map" do
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"ok":true,"foo":"bar"})}}
+
+      assert {:ok, %{ok: true, foo: "bar"}} = SlackAPI.parse_response(response)
+    end
+
+    test "surfaces a 429 as a ratelimited body with retry_after from the header" do
+      response =
+        {:ok, %HTTPoison.Response{status_code: 429, headers: [{"Retry-After", "12"}], body: ""}}
+
+      assert {:ok, %{ok: false, error: "ratelimited", retry_after: 12}} =
+               SlackAPI.parse_response(response)
+    end
+
+    test "matches the Retry-After header case-insensitively" do
+      response =
+        {:ok, %HTTPoison.Response{status_code: 429, headers: [{"retry-after", "5"}], body: ""}}
+
+      assert {:ok, %{retry_after: 5}} = SlackAPI.parse_response(response)
+    end
+
+    test "defaults retry_after when the header is missing or unparseable" do
+      missing = {:ok, %HTTPoison.Response{status_code: 429, headers: [], body: ""}}
+
+      garbage =
+        {:ok, %HTTPoison.Response{status_code: 429, headers: [{"Retry-After", "soon"}], body: ""}}
+
+      assert {:ok, %{retry_after: 30}} = SlackAPI.parse_response(missing)
+      assert {:ok, %{retry_after: 30}} = SlackAPI.parse_response(garbage)
+    end
+  end
+
+  describe "render_response/1" do
+    test "turns a 429 into a ratelimited error tuple with retry_after" do
+      response =
+        {:ok, %HTTPoison.Response{status_code: 429, headers: [{"Retry-After", "20"}], body: ""}}
+
+      assert {:error, %{ok: false, error: "ratelimited", retry_after: 20}} =
+               SlackAPI.render_response(response)
+    end
+
+    test "returns an ok tuple for a successful body" do
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"ok":true})}}
+
+      assert {:ok, %{ok: true}} = SlackAPI.render_response(response)
+    end
+
+    test "returns an error tuple for an ok:false body" do
+      response =
+        {:ok,
+         %HTTPoison.Response{status_code: 200, body: ~s({"ok":false,"error":"invalid_auth"})}}
+
+      assert {:error, %{ok: false, error: "invalid_auth"}} = SlackAPI.render_response(response)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Juvet.SlackAPI.parse_response/1` previously only inspected the response **body**, so a Slack **HTTP 429** (rate limit) — which comes with an empty/non-JSON body and a `Retry-After` header — fell through `Poison.decode` as an opaque parse error. Consumers had no way to know they were rate-limited, let alone for how long.

This special-cases 429 to return an `ok: false` body with:
- `error: "ratelimited"`
- `retry_after:` seconds, read **case-insensitively** from the `Retry-After` header (defaults to 30s when the header is absent or unparseable)

`render_response/1` then turns it into the usual `{:error, %{error: "ratelimited", retry_after: n}}` tuple via the existing `ok: false` path, so callers can back off for exactly the duration Slack asks for.

## Why

A downstream consumer (Tatsu's customer-broadcast send pipeline) needs to honor `Retry-After` when fanning out bulk DMs so it backs off correctly instead of hammering Slack / wasting retries.

## Tests

Adds `test/juvet/slack_api_test.exs` with direct unit coverage for `parse_response/1` and `render_response/1` (success, `ok: false`, 429 with header, case-insensitive header, default fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)