### PR TITLE
feat(template): support top-level blocks: for message templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Templates can now have a top-level `blocks:` (no `.view` wrapper), which
+  compiles to a bare list of blocks — suitable for a Slack **message**
+  (`chat.postMessage`) rather than a modal/home view. The generated function
+  returns the block list directly. A loose list of top-level elements (without a
+  `blocks:` key) is rejected with a clear error.
 - `Juvet.SlackAPI` now surfaces rate limiting: a Slack `HTTP 429` response is
   parsed into an `ok: false` body with `error: "ratelimited"` and a
   `retry_after` value (seconds) read from the `Retry-After` header, so callers

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -149,6 +149,31 @@ Juvet does not validate Slack's contract (e.g., `title.text` &le; 24 characters,
 The template layer then either returns the map directly (`:map` format, the default)
 or encodes it to JSON (`:json` format) via `Encoder.encode!/1`.
 
+### Message blocks (top-level `blocks:`)
+
+A template can omit the `.view` wrapper and declare a top-level `blocks:` instead.
+This compiles to a **bare list of blocks** rather than a view map — use it for a
+Slack message (`chat.postMessage`), which takes a top-level `blocks` array.
+
+```elixir
+# cheex source (a `.slack.cheex` file, so the platform is :slack):
+#
+# blocks:
+#   :slack.section{text: "Heads up <%= name %>", type: :mrkdwn}
+#   :slack.divider
+
+[
+  %{type: "section", text: %{type: "mrkdwn", text: "Heads up Sam"}},
+  %{type: "divider"}
+]
+```
+
+The generated function returns the list directly, e.g.
+`MyTemplates.message(name: "Sam")`. EEx interpolation and `<%= if %>`/`<%= for %>`
+work inside `blocks:` just as they do inside a view. A loose list of top-level
+elements (without the `blocks:` key) is rejected — a template must be a single
+`.view` or a top-level `blocks:`.
+
 ## Compiler Architecture
 
 The compiler delegates to platform-specific compilers based on the `platform:` field in each AST element.

--- a/lib/juvet/template.ex
+++ b/lib/juvet/template.ex
@@ -760,6 +760,20 @@ defmodule Juvet.Template do
     end
   end
 
+  # Blocks-only template (no `.view` wrapper): `compiled` is a list of blocks.
+  # `compiled_to_quoted/2` already handles list bodies (static, EEx, if, for).
+  defp generate_json_function(name, compiled, helper_bindings) when is_list(compiled) do
+    bindings_var = Macro.var(:bindings, __MODULE__)
+    body = compiled_to_quoted(compiled, bindings_var)
+
+    quote do
+      def unquote(name)(bindings \\ []) do
+        unquote(bindings_var) = Keyword.merge(unquote(helper_bindings), bindings)
+        Juvet.Template.Compiler.Encoder.encode!(unquote(body))
+      end
+    end
+  end
+
   defp generate_map_function(name, compiled, helper_bindings) when is_map(compiled) do
     cond do
       map_contains_dynamic_marker?(compiled) ->
@@ -789,6 +803,20 @@ defmodule Juvet.Template do
         quote do
           def unquote(name)(_bindings \\ []), do: unquote(escaped)
         end
+    end
+  end
+
+  # Blocks-only template (no `.view` wrapper): `compiled` is a list of blocks.
+  # `compiled_to_quoted/2` already handles list bodies (static, EEx, if, for).
+  defp generate_map_function(name, compiled, helper_bindings) when is_list(compiled) do
+    bindings_var = Macro.var(:bindings, __MODULE__)
+    body = compiled_to_quoted(compiled, bindings_var)
+
+    quote do
+      def unquote(name)(bindings \\ []) do
+        unquote(bindings_var) = Keyword.merge(unquote(helper_bindings), bindings)
+        unquote(body)
+      end
     end
   end
 

--- a/lib/juvet/template/compiler/slack.ex
+++ b/lib/juvet/template/compiler/slack.ex
@@ -61,8 +61,29 @@ defmodule Juvet.Template.Compiler.Slack do
 
   alias Juvet.Template.Compiler.Slack.View
 
-  @spec compile([Compiler.ast_element()]) :: map()
+  @spec compile([Compiler.ast_element()]) :: map() | [map()]
   def compile([%{element: :view} = view]), do: View.compile(view)
+
+  # A top-level `blocks:` template (no `.view` wrapper) compiles to a bare list
+  # of blocks, suitable for a Slack message (`chat.postMessage`) rather than a
+  # modal/home view.
+  def compile([%{element: :blocks} = node]), do: compile_block_list(node)
+
+  # A template must be a single `.view` or a top-level `blocks:` list — a loose
+  # list of top-level elements is not a valid template.
+  def compile(elements) when is_list(elements) do
+    raise ArgumentError,
+          "a Slack template must be a single `.view` or a top-level `blocks:` list, " <>
+            "got top-level element(s): #{inspect(Enum.map(elements, &Map.get(&1, :element)))}"
+  end
+
+  defp compile_block_list(%{children: %{blocks: blocks}}) when is_list(blocks),
+    do: Enum.map(blocks, &compile_element/1)
+
+  defp compile_block_list(%{children: %{blocks: block}}) when is_map(block),
+    do: [compile_element(block)]
+
+  defp compile_block_list(_), do: []
 
   @doc false
   @spec compile_element(Compiler.ast_element() | map()) :: map()

--- a/lib/juvet/template/parser.ex
+++ b/lib/juvet/template/parser.ex
@@ -95,6 +95,27 @@ defmodule Juvet.Template.Parser do
       column: col
   end
 
+  # Top-level `blocks:` (no `.view` wrapper) — a message's block list. Requires a
+  # known platform (e.g. a `.slack.cheex` file) to resolve `.element` shorthand.
+  defp do_parse(
+         [{:keyword, "blocks", pos}, {:colon, _, _}, {:newline, _, _}, {:indent, _, _} | rest],
+         acc,
+         platform
+       )
+       when not is_nil(platform) do
+    {nested, rest} = nested_elements(rest, [], platform)
+
+    node = %{
+      platform: platform,
+      element: :blocks,
+      line: elem(pos, 0),
+      column: elem(pos, 1),
+      children: %{blocks: child_value(nested)}
+    }
+
+    do_parse(rest, [node | acc], platform)
+  end
+
   # Unexpected token at top level
   defp do_parse([{type, value, {line, col}} | _], _acc, _platform) do
     raise ParserError,

--- a/test/juvet/template_test.exs
+++ b/test/juvet/template_test.exs
@@ -100,6 +100,56 @@ defmodule Juvet.TemplateTest do
     end
   end
 
+  # A top-level `blocks:` (no `.view` wrapper) compiles to a bare list of blocks,
+  # for a Slack message rather than a modal/home view.
+  describe "blocks-only templates (top-level blocks:)" do
+    defmodule MessageTemplates do
+      use Juvet.Template
+
+      template(:message, file: "templates/blocks_message.slack.cheex")
+    end
+
+    test "compiles to a bare list of blocks, interpolating bindings" do
+      assert MessageTemplates.message(name: "World", show_extra: false) == [
+               %{type: "section", text: %{type: "mrkdwn", text: "Hi World"}},
+               %{
+                 type: "actions",
+                 elements: [
+                   %{type: "button", text: %{type: "plain_text", text: "Go"}, action_id: "go"}
+                 ]
+               }
+             ]
+    end
+
+    test "supports conditionals within the block list" do
+      assert MessageTemplates.message(name: "X", show_extra: true) == [
+               %{type: "section", text: %{type: "mrkdwn", text: "Hi X"}},
+               %{type: "divider"},
+               %{
+                 type: "actions",
+                 elements: [
+                   %{type: "button", text: %{type: "plain_text", text: "Go"}, action_id: "go"}
+                 ]
+               }
+             ]
+    end
+
+    test "a loose top-level element list (no blocks:) is rejected" do
+      assert_raise CompileError, ~r/a Slack template must be a single/, fn ->
+        Code.compile_string("""
+        defmodule LooseBlocks do
+          use Juvet.Template
+
+          template(:loose, \"\"\"
+          :slack.section{text: "Hi", type: :mrkdwn}
+          :slack.divider
+          \"\"\")
+        end
+        """)
+      end
+    end
+  end
+
   describe "compile-time errors" do
     test "invalid template syntax raises CompileError" do
       assert_raise CompileError, ~r/template :bad has a syntax error/, fn ->

--- a/test/juvet/templates/blocks_message.slack.cheex
+++ b/test/juvet/templates/blocks_message.slack.cheex
@@ -1,0 +1,12 @@
+blocks:
+  .section
+    text: "Hi <%= name %>"
+    type: :mrkdwn
+  <%= if show_extra do %>
+    .divider
+  <% end %>
+  .actions
+    elements:
+      .button
+        text: "Go"
+        action_id: "go"


### PR DESCRIPTION
## Summary
Lets a cheex template render a Slack **message's** block list (for `chat.postMessage`) as a first-class template, instead of forcing every template to be a modal/home `.view`. A template can now declare a top-level **`blocks:`** (no `.view` wrapper); it compiles to a bare list of blocks and the generated function returns that list directly.

```
# a `.slack.cheex` file
blocks:
  .section{text: "Heads up <%= name %>", type: :mrkdwn}
  .divider
```
→ `MyTemplates.message(name: "Sam")` returns `[%{type: "section", …}, %{type: "divider"}]`.

## Changes
- **Parser** (`parser.ex`): accept a top-level `blocks:` key (with a known platform, e.g. a `.slack.cheex` file) → a `:blocks` AST node carrying the nested blocks.
- **Slack compiler** (`compiler/slack.ex`): `compile([%{element: :blocks}])` → the compiled block list. A loose list of top-level elements **without** a `blocks:` key is rejected with a clear error (a template must be a single `.view` or a top-level `blocks:`).
- **Template codegen** (`template.ex`): `generate_map_function`/`generate_json_function` handle a list-shaped compiled result, delegating to the already list-capable `compiled_to_quoted/2` (so static, EEx, `if`, and `for` all work inside `blocks:`).
- Tests, CHANGELOG, `docs/templates.md`.

## Notes
- Based on `feature/slack-api-retry-after` (juvet#134) so the diff shows only the blocks change; retarget to `main` once #134 merges.
- Full suite green (736 tests); format + credo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)